### PR TITLE
feat: Users starter page with MSW mocks and dark mode

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "files": {
+    "ignore": ["public/mockServiceWorker.js", "dist/**"]
+  },
   "organizeImports": {
     "enabled": true
   },

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Agent Team Starter</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -41,5 +41,8 @@
     "@biomejs/biome": "^1.9.4",
     "tailwindcss": "^4.0.0",
     "@tailwindcss/vite": "^4.0.0"
+  },
+  "msw": {
+    "workerDirectory": ["public"]
   }
 }

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -1,0 +1,349 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ */
+
+const PACKAGE_VERSION = '2.13.4'
+const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
+
+addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+addEventListener('message', async function (event) {
+  const clientId = Reflect.get(event.source || {}, 'id')
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: {
+          client: {
+            id: client.id,
+            frameType: client.frameType,
+          },
+        },
+      })
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+addEventListener('fetch', function (event) {
+  const requestInterceptedAt = Date.now()
+
+  // Bypass navigation requests.
+  if (event.request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (
+    event.request.cache === 'only-if-cached' &&
+    event.request.mode !== 'same-origin'
+  ) {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been terminated (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId, requestInterceptedAt))
+})
+
+/**
+ * @param {FetchEvent} event
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ */
+async function handleRequest(event, requestId, requestInterceptedAt) {
+  const client = await resolveMainClient(event)
+  const requestCloneForEvents = event.request.clone()
+  const response = await getResponse(
+    event,
+    client,
+    requestId,
+    requestInterceptedAt,
+  )
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    const serializedRequest = await serializeRequest(requestCloneForEvents)
+
+    // Clone the response so both the client and the library could consume it.
+    const responseClone = response.clone()
+
+    sendToClient(
+      client,
+      {
+        type: 'RESPONSE',
+        payload: {
+          isMockedResponse: IS_MOCKED_RESPONSE in response,
+          request: {
+            id: requestId,
+            ...serializedRequest,
+          },
+          response: {
+            type: responseClone.type,
+            status: responseClone.status,
+            statusText: responseClone.statusText,
+            headers: Object.fromEntries(responseClone.headers.entries()),
+            body: responseClone.body,
+          },
+        },
+      },
+      responseClone.body ? [serializedRequest.body, responseClone.body] : [],
+    )
+  }
+
+  return response
+}
+
+/**
+ * Resolve the main client for the given event.
+ * Client that issues a request doesn't necessarily equal the client
+ * that registered the worker. It's with the latter the worker should
+ * communicate with during the response resolving phase.
+ * @param {FetchEvent} event
+ * @returns {Promise<Client | undefined>}
+ */
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (activeClientIds.has(event.clientId)) {
+    return client
+  }
+
+  if (client?.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+/**
+ * @param {FetchEvent} event
+ * @param {Client | undefined} client
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ * @returns {Promise<Response>}
+ */
+async function getResponse(event, client, requestId, requestInterceptedAt) {
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = event.request.clone()
+
+  function passthrough() {
+    // Cast the request headers to a new Headers instance
+    // so the headers can be manipulated with.
+    const headers = new Headers(requestClone.headers)
+
+    // Remove the "accept" header value that marked this request as passthrough.
+    // This prevents request alteration and also keeps it compliant with the
+    // user-defined CORS policies.
+    const acceptHeader = headers.get('accept')
+    if (acceptHeader) {
+      const values = acceptHeader.split(',').map((value) => value.trim())
+      const filteredValues = values.filter(
+        (value) => value !== 'msw/passthrough',
+      )
+
+      if (filteredValues.length > 0) {
+        headers.set('accept', filteredValues.join(', '))
+      } else {
+        headers.delete('accept')
+      }
+    }
+
+    return fetch(requestClone, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const serializedRequest = await serializeRequest(event.request)
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: 'REQUEST',
+      payload: {
+        id: requestId,
+        interceptedAt: requestInterceptedAt,
+        ...serializedRequest,
+      },
+    },
+    [serializedRequest.body],
+  )
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'PASSTHROUGH': {
+      return passthrough()
+    }
+  }
+
+  return passthrough()
+}
+
+/**
+ * @param {Client} client
+ * @param {any} message
+ * @param {Array<Transferable>} transferrables
+ * @returns {Promise<any>}
+ */
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(message, [
+      channel.port2,
+      ...transferrables.filter(Boolean),
+    ])
+  })
+}
+
+/**
+ * @param {Response} response
+ * @returns {Response}
+ */
+function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error()
+  }
+
+  const mockedResponse = new Response(response.body, response)
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  })
+
+  return mockedResponse
+}
+
+/**
+ * @param {Request} request
+ */
+async function serializeRequest(request) {
+  return {
+    url: request.url,
+    mode: request.mode,
+    method: request.method,
+    headers: Object.fromEntries(request.headers.entries()),
+    cache: request.cache,
+    credentials: request.credentials,
+    destination: request.destination,
+    integrity: request.integrity,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    body: await request.arrayBuffer(),
+    keepalive: request.keepalive,
+  }
+}

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,37 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it } from "vitest";
+import { App } from "./App";
+import { useUiStore } from "./store/uiStore";
+import { renderWithProviders } from "./test/utils";
+
+describe("App dark mode", () => {
+  beforeEach(() => {
+    useUiStore.setState({ darkMode: false });
+  });
+
+  it("does not apply the 'dark' class initially", () => {
+    renderWithProviders(<App />);
+    const wrapper = screen.getByTestId("app-root");
+    expect(wrapper).not.toHaveClass("dark");
+  });
+
+  it("adds the 'dark' class when the toggle button is clicked", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<App />);
+    const button = screen.getByRole("button", { name: /toggle dark mode/i });
+    await user.click(button);
+    const wrapper = screen.getByTestId("app-root");
+    expect(wrapper).toHaveClass("dark");
+  });
+
+  it("removes the 'dark' class when the toggle button is clicked twice", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<App />);
+    const button = screen.getByRole("button", { name: /toggle dark mode/i });
+    await user.click(button);
+    await user.click(button);
+    const wrapper = screen.getByTestId("app-root");
+    expect(wrapper).not.toHaveClass("dark");
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,35 @@
+import { UsersPage } from "./pages/UsersPage";
+import { useUiStore } from "./store/uiStore";
+
+export function App() {
+  const darkMode = useUiStore((s) => s.darkMode);
+  const toggleDarkMode = useUiStore((s) => s.toggleDarkMode);
+
+  return (
+    // 'dark' class is applied to app-root wrapper, not document.html — tests assert on this element
+    <div
+      data-testid="app-root"
+      className={
+        darkMode
+          ? "dark min-h-screen bg-gray-900 text-white"
+          : "min-h-screen bg-gray-50 text-gray-900"
+      }
+    >
+      <header className="flex items-center justify-between border-b border-gray-200 p-4 dark:border-gray-700">
+        <h1 className="text-xl font-semibold">Agent Team Starter</h1>
+        <button
+          type="button"
+          aria-label="Toggle dark mode"
+          aria-pressed={darkMode}
+          onClick={toggleDarkMode}
+          className="rounded border border-gray-300 px-3 py-1 text-sm dark:border-gray-600"
+        >
+          {darkMode ? "Light mode" : "Dark mode"}
+        </button>
+      </header>
+      <main className="p-4">
+        <UsersPage />
+      </main>
+    </div>
+  );
+}

--- a/src/api/users.test.tsx
+++ b/src/api/users.test.tsx
@@ -1,0 +1,77 @@
+import { type QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import type { ReactNode } from "react";
+import { describe, expect, it } from "vitest";
+import { ZodError } from "zod";
+import { server } from "../mocks/server";
+import { createTestQueryClient } from "../test/utils";
+import { fetchUsers, queryKeys, useUsers } from "./users";
+
+function wrapper(queryClient: QueryClient) {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe("queryKeys.users.all", () => {
+  it("returns the readonly tuple ['users']", () => {
+    const key = queryKeys.users.all();
+    expect(key).toEqual(["users"]);
+  });
+});
+
+describe("fetchUsers", () => {
+  it("returns a parsed array of users on success", async () => {
+    const users = await fetchUsers();
+    expect(Array.isArray(users)).toBe(true);
+    expect(users.length).toBeGreaterThan(0);
+    expect(users[0]).toMatchObject({
+      id: expect.any(String),
+      name: expect.any(String),
+      email: expect.any(String),
+      role: expect.stringMatching(/^(admin|member)$/),
+    });
+  });
+
+  it("throws an error on a non-ok response", async () => {
+    server.use(http.get("/api/users", () => new HttpResponse(null, { status: 500 })));
+    await expect(fetchUsers()).rejects.toThrow(/HTTP 500/);
+  });
+
+  it("throws a ZodError when the server returns malformed data", async () => {
+    server.use(http.get("/api/users", () => HttpResponse.json({ broken: true })));
+    await expect(fetchUsers()).rejects.toBeInstanceOf(ZodError);
+  });
+});
+
+describe("useUsers", () => {
+  it("starts in a loading state and resolves with data", async () => {
+    const queryClient = createTestQueryClient();
+    const { result } = renderHook(() => useUsers(), { wrapper: wrapper(queryClient) });
+
+    expect(result.current.isPending).toBe(true);
+    expect(result.current.data).toBeUndefined();
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toBeDefined();
+    expect(Array.isArray(result.current.data)).toBe(true);
+    expect(result.current.data?.length).toBeGreaterThan(0);
+  });
+
+  it("enters error state when the server returns a 500", async () => {
+    server.use(http.get("/api/users", () => new HttpResponse(null, { status: 500 })));
+    const queryClient = createTestQueryClient();
+    const { result } = renderHook(() => useUsers(), { wrapper: wrapper(queryClient) });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect((result.current.error as Error).message).toMatch(/HTTP 500/);
+  });
+});

--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -1,0 +1,33 @@
+import { useQuery } from "@tanstack/react-query";
+import { z } from "zod";
+
+export const UserSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  email: z.string().email(),
+  role: z.enum(["admin", "member"]),
+});
+
+export const UsersResponseSchema = z.array(UserSchema);
+
+export type User = z.infer<typeof UserSchema>;
+
+export const queryKeys = {
+  users: {
+    all: () => ["users"] as const,
+  },
+} as const;
+
+export async function fetchUsers(): Promise<User[]> {
+  const res = await fetch("/api/users");
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const json = await res.json();
+  return UsersResponseSchema.parse(json);
+}
+
+export function useUsers() {
+  return useQuery({
+    queryKey: queryKeys.users.all(),
+    queryFn: fetchUsers,
+  });
+}

--- a/src/components/LoadingSkeleton.test.tsx
+++ b/src/components/LoadingSkeleton.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { LoadingSkeleton } from "./LoadingSkeleton";
+
+describe("LoadingSkeleton", () => {
+  it("renders exactly 3 skeleton items", () => {
+    render(<LoadingSkeleton />);
+    const items = screen.getAllByTestId("skeleton-item");
+    expect(items).toHaveLength(3);
+  });
+
+  it("applies the animate-pulse class to each skeleton item", () => {
+    render(<LoadingSkeleton />);
+    const items = screen.getAllByTestId("skeleton-item");
+    for (const item of items) {
+      expect(item).toHaveClass("animate-pulse");
+    }
+  });
+});

--- a/src/components/LoadingSkeleton.tsx
+++ b/src/components/LoadingSkeleton.tsx
@@ -1,0 +1,18 @@
+const SKELETON_KEYS = ["skeleton-1", "skeleton-2", "skeleton-3"] as const;
+
+export function LoadingSkeleton() {
+  return (
+    <ul aria-label="Loading users" className="space-y-3">
+      {SKELETON_KEYS.map((key) => (
+        <li
+          key={key}
+          data-testid="skeleton-item"
+          className="animate-pulse rounded-lg border border-gray-200 bg-white p-4 dark:bg-gray-800"
+        >
+          <div className="mb-2 h-4 w-1/3 rounded bg-gray-200 dark:bg-gray-700" />
+          <div className="h-3 w-1/2 rounded bg-gray-200 dark:bg-gray-700" />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/UserCard.test.tsx
+++ b/src/components/UserCard.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { User } from "../api/users";
+import { UserCard } from "./UserCard";
+
+const adminUser: User = {
+  id: "550e8400-e29b-41d4-a716-446655440001",
+  name: "Alice Admin",
+  email: "alice@example.com",
+  role: "admin",
+};
+
+const memberUser: User = {
+  id: "550e8400-e29b-41d4-a716-446655440002",
+  name: "Bob Member",
+  email: "bob@example.com",
+  role: "member",
+};
+
+describe("UserCard", () => {
+  it("renders the user's name, email and role", () => {
+    render(<UserCard user={adminUser} />);
+    expect(screen.getByText("Alice Admin")).toBeInTheDocument();
+    expect(screen.getByText("alice@example.com")).toBeInTheDocument();
+    expect(screen.getByText("admin")).toBeInTheDocument();
+  });
+
+  it("shows an 'admin' badge for an admin user", () => {
+    render(<UserCard user={adminUser} />);
+    expect(screen.getByText("admin")).toBeInTheDocument();
+  });
+
+  it("shows a 'member' badge for a member user", () => {
+    render(<UserCard user={memberUser} />);
+    expect(screen.getByText("member")).toBeInTheDocument();
+  });
+});

--- a/src/components/UserCard.tsx
+++ b/src/components/UserCard.tsx
@@ -1,0 +1,27 @@
+import type { User } from "../api/users";
+
+interface UserCardProps {
+  user: User;
+}
+
+export function UserCard({ user }: UserCardProps) {
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="font-medium">{user.name}</p>
+          <p className="text-sm text-gray-500 dark:text-gray-400">{user.email}</p>
+        </div>
+        <span
+          className={
+            user.role === "admin"
+              ? "rounded-full bg-purple-100 px-2 py-0.5 text-xs text-purple-800 dark:bg-purple-900 dark:text-purple-200"
+              : "rounded-full bg-blue-100 px-2 py-0.5 text-xs text-blue-800 dark:bg-blue-900 dark:text-blue-200"
+          }
+        >
+          {user.role}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,2 @@
+@import "tailwindcss";
+@custom-variant dark (&:where(.dark, .dark *));

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,26 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { App } from "./App";
+import "./index.css";
+
+const queryClient = new QueryClient();
+
+async function prepare() {
+  if (import.meta.env.DEV) {
+    const { worker } = await import("./mocks/browser");
+    await worker.start({ onUnhandledRequest: "bypass" });
+  }
+}
+
+prepare().then(() => {
+  const root = document.getElementById("root");
+  if (!root) throw new Error("Root element not found");
+  ReactDOM.createRoot(root).render(
+    <React.StrictMode>
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>
+    </React.StrictMode>
+  );
+});

--- a/src/mocks/browser.ts
+++ b/src/mocks/browser.ts
@@ -1,0 +1,4 @@
+import { setupWorker } from "msw/browser";
+import { handlers } from "./handlers";
+
+export const worker = setupWorker(...handlers);

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,0 +1,30 @@
+import { http, HttpResponse } from "msw";
+
+export const userFixtures = [
+  {
+    id: "550e8400-e29b-41d4-a716-446655440001",
+    name: "Alice Admin",
+    email: "alice@example.com",
+    role: "admin" as const,
+  },
+  {
+    id: "550e8400-e29b-41d4-a716-446655440002",
+    name: "Bob Member",
+    email: "bob@example.com",
+    role: "member" as const,
+  },
+  {
+    id: "550e8400-e29b-41d4-a716-446655440003",
+    name: "Carol Admin",
+    email: "carol@example.com",
+    role: "admin" as const,
+  },
+  {
+    id: "550e8400-e29b-41d4-a716-446655440004",
+    name: "Dan Member",
+    email: "dan@example.com",
+    role: "member" as const,
+  },
+];
+
+export const handlers = [http.get("/api/users", () => HttpResponse.json(userFixtures))];

--- a/src/mocks/server.ts
+++ b/src/mocks/server.ts
@@ -1,0 +1,4 @@
+import { setupServer } from "msw/node";
+import { handlers } from "./handlers";
+
+export const server = setupServer(...handlers);

--- a/src/pages/UsersPage.test.tsx
+++ b/src/pages/UsersPage.test.tsx
@@ -1,0 +1,45 @@
+import { screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it } from "vitest";
+import { server } from "../mocks/server";
+import { useUiStore } from "../store/uiStore";
+import { renderWithProviders } from "../test/utils";
+import { UsersPage } from "./UsersPage";
+
+describe("UsersPage", () => {
+  beforeEach(() => {
+    useUiStore.setState({ darkMode: false });
+  });
+
+  it("shows the loading skeleton while fetching", () => {
+    renderWithProviders(<UsersPage />);
+    expect(screen.getAllByTestId("skeleton-item").length).toBeGreaterThan(0);
+  });
+
+  it("renders all 4 users from the fixture after load", async () => {
+    renderWithProviders(<UsersPage />);
+    await waitFor(() => {
+      expect(screen.getByText("Alice Admin")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Alice Admin")).toBeInTheDocument();
+    expect(screen.getByText("Bob Member")).toBeInTheDocument();
+    expect(screen.getByText("Carol Admin")).toBeInTheDocument();
+    expect(screen.getByText("Dan Member")).toBeInTheDocument();
+  });
+
+  it("shows an error message when the API returns a 500", async () => {
+    server.use(http.get("/api/users", () => new HttpResponse(null, { status: 500 })));
+    renderWithProviders(<UsersPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/error/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows an empty state when the API returns an empty array", async () => {
+    server.use(http.get("/api/users", () => HttpResponse.json([])));
+    renderWithProviders(<UsersPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/no users found\./i)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/pages/UsersPage.tsx
+++ b/src/pages/UsersPage.tsx
@@ -1,0 +1,31 @@
+import { useUsers } from "../api/users";
+import { LoadingSkeleton } from "../components/LoadingSkeleton";
+import { UserCard } from "../components/UserCard";
+
+export function UsersPage() {
+  const { data, isPending, isError, error } = useUsers();
+
+  if (isPending) return <LoadingSkeleton />;
+
+  if (isError) {
+    return (
+      <div role="alert" className="p-4 text-red-600 dark:text-red-400">
+        Error loading users: {error instanceof Error ? error.message : "Unknown error"}
+      </div>
+    );
+  }
+
+  if (data.length === 0) {
+    return <p className="p-4 text-gray-500">No users found.</p>;
+  }
+
+  return (
+    <ul className="space-y-3">
+      {data.map((user) => (
+        <li key={user.id}>
+          <UserCard user={user} />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/store/uiStore.test.ts
+++ b/src/store/uiStore.test.ts
@@ -1,0 +1,23 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useUiStore } from "./uiStore";
+
+describe("useUiStore", () => {
+  beforeEach(() => {
+    useUiStore.setState({ darkMode: false });
+  });
+
+  it("has darkMode=false as the initial state", () => {
+    expect(useUiStore.getState().darkMode).toBe(false);
+  });
+
+  it("toggleDarkMode flips darkMode to true", () => {
+    useUiStore.getState().toggleDarkMode();
+    expect(useUiStore.getState().darkMode).toBe(true);
+  });
+
+  it("calling toggleDarkMode twice returns darkMode to false", () => {
+    useUiStore.getState().toggleDarkMode();
+    useUiStore.getState().toggleDarkMode();
+    expect(useUiStore.getState().darkMode).toBe(false);
+  });
+});

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -1,0 +1,11 @@
+import { create } from "zustand";
+
+type UiState = {
+  darkMode: boolean;
+  toggleDarkMode: () => void;
+};
+
+export const useUiStore = create<UiState>((set) => ({
+  darkMode: false,
+  toggleDarkMode: () => set((state) => ({ darkMode: !state.darkMode })),
+}));

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,7 @@
+import "@testing-library/jest-dom/vitest";
+import { afterAll, afterEach, beforeAll } from "vitest";
+import { server } from "../mocks/server";
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());

--- a/src/test/utils.tsx
+++ b/src/test/utils.tsx
@@ -1,0 +1,32 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { type RenderOptions, type RenderResult, render } from "@testing-library/react";
+import type { ReactElement, ReactNode } from "react";
+
+export function createTestQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: 0,
+        gcTime: 0,
+        staleTime: Number.POSITIVE_INFINITY,
+      },
+      mutations: {
+        retry: 0,
+      },
+    },
+  });
+}
+
+export function renderWithProviders(
+  ui: ReactElement,
+  options?: Omit<RenderOptions, "wrapper"> & { queryClient?: QueryClient }
+): RenderResult & { queryClient: QueryClient } {
+  const queryClient = options?.queryClient ?? createTestQueryClient();
+
+  function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  }
+
+  const result = render(ui, { wrapper: Wrapper, ...options });
+  return { ...result, queryClient };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom", "vite/client"]
+  },
+  "include": ["src"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,14 @@
+import tailwindcss from "@tailwindcss/vite";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["src/test/setup.ts"],
+    include: ["src/**/*.{test,spec}.{ts,tsx}"],
+    css: false,
+  },
+});


### PR DESCRIPTION
## Summary

- Bootstraps the entire React app from scratch: Vite config, TypeScript strict mode, Tailwind v4, index.html entry
- `UsersPage` fetches from `GET /api/users` (MSW-mocked) and renders all four states: loading skeleton, error, empty, and data
- Zod schema (`UserSchema`) is the single source of truth for the `User` type — no hand-written interfaces; TanStack Query `queryKeys` factory exported for cache invalidation
- Dark mode preference stored in Zustand (client state only, never mixed with server state); toggled via an accessible button with `aria-pressed`
- MSW handlers serve 4 fixture users (real UUIDs) in development (`browser.ts` worker) and in tests (`server.ts` Node adapter)

## Test plan

- [x] `pnpm typecheck` — clean (strict mode, no `any`, no `@ts-ignore`)
- [x] `pnpm test` — 21/21 passing across 6 test files
  - `uiStore`: initial state, toggle on, toggle off
  - `UserCard`: name/email/role render, admin badge, member badge
  - `LoadingSkeleton`: renders exactly 3 skeleton items with `data-testid`
  - `users.ts`: queryKeys tuple, fetchUsers happy/500/malformed-Zod, useUsers loading→success, useUsers error state
  - `UsersPage`: loading skeleton, all 4 fixture users, 500 error message, empty state
  - `App`: dark mode absent initially, applied on click, removed on second click
- [x] `pnpm lint` — Biome clean (import order, formatting, no unused imports)
- [x] `pnpm build` — 240 kB bundle, no warnings

## Known limitations / follow-up

- **Chrome DevTools MCP verification not completed** — the MCP server was not configured in the session that ran this pipeline. Before merging, open `http://localhost:5173` (`pnpm dev`) and confirm: (1) users list renders, (2) browser console is clean (MSW "Mocking enabled" is expected), (3) dark mode toggle works visually. Screenshots should be attached per CLAUDE.md DoD.
- No E2E tests yet — Playwright harness is installed but `playwright.config.ts` is not set up; `pnpm test:e2e` will warn until configured.
- Dark mode is session-only — preference is not persisted to `localStorage`. Intentional for this starter; add persistence when needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)