### PR TITLE
chore: add Oxlint, tsgo typecheck, and Fallow

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -2,7 +2,7 @@
 name: architect
 description: Produces implementation plans for React/Zustand/TanStack Query/Zod features. Read-only.
 tools: Read, Grep, Glob, WebFetch
-model: sonnet
+model: opus 
 isolation: worktree
 ---
 You turn feature specs into concrete plans for this stack.

--- a/.claude/agents/builder.md
+++ b/.claude/agents/builder.md
@@ -2,7 +2,7 @@
 name: builder
 description: TDD loop — tests first, then implementation, verify with Chrome DevTools MCP.
 tools: Read, Write, Edit, Bash, Grep, Glob, mcp__chrome-devtools
-model: opus
+model: sonnet
 isolation: worktree
 ---
 You practice strict TDD for React + Zustand + TanStack Query + Zod.
@@ -22,8 +22,16 @@ Phase 2 — Implement:
 - Zustand stores only for client state, with selector-based consumers
 - After each green test, run the full suite to check for regressions
 
-Phase 3 — Verify (Chrome DevTools MCP):
+Phase 3 — Verify (fallow + Chrome DevTools MCP):
 
+Fallow static audit (run before opening the browser):
+1. `pnpm fallow audit --format json` — check the `verdict` field
+   - `pass`: continue
+   - `warn`: note findings in the PR, continue
+   - `fail`: fix new dead code / duplication / complexity issues before proceeding. Use `fallow dead-code`, `fallow dupes`, and `fallow health --targets` to locate them. Do NOT proceed to browser verification with a `fail` verdict.
+2. Attach the audit JSON summary to the mailbox alongside screenshots
+
+Chrome DevTools MCP (browser verification):
 Prerequisites:
 - Start and wait for dev server: `pnpm dev:ready` (exits 0 when ready, non-zero on timeout with tail of log)
 - On completion or error, always run: `pnpm dev:stop`

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -13,6 +13,9 @@ Diff checks:
 - All API boundaries go through a Zod schema
 - Query keys imported from factory, not inlined
 - Loading/error/empty states handled in every new async component
+- `fallow audit` verdict is `pass` or `warn` (never `fail`) — confirm the JSON summary is attached or run `pnpm fallow audit` yourself
+- No new unused exports, unused files, or circular dependencies introduced (check fallow dead-code findings)
+- No significant complexity regression: if any function exceeds the health thresholds, flag it
 - Chrome DevTools MCP verification artifacts present: happy-path.png, error-path.png, clean console log, clean network log
 - For perf-sensitive changes: performance trace attached
 - No leftover debug code, commented blocks, or unreferenced exports

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -9,7 +9,8 @@ You are the Lead. Execute this pipeline:
 2. Spawn `critic` to review plan. If BLOCK, loop to step 1 with critic's notes (max 2 rounds, then escalate).
 3. Spawn `builder` with approved plan. Instruct: Phase 1 only (write tests).
 4. Spawn `critic` to review tests. If BLOCK, send notes to builder (max 2 rounds, then escalate).
-5. Instruct `builder` to proceed to Phase 2 (implement) and Phase 3 (verify).
-6. Spawn `reviewer` on the final diff. If BLOCK, send notes to builder (max 1 round — reviewer-blocked fixes should be small).
-7. If approved: commit, push the worktree branch, run `gh pr create` with reviewer's description.
-8. If any agent escalates or exceeds retry budget, stop and summarize state.
+5. Instruct `builder` to proceed to Phase 2 (implement) and Phase 3 (verify). Phase 3 includes: fallow audit (must not be `fail`) then Chrome DevTools MCP screenshots.
+6. After builder signals done, run `pnpm fallow audit --format json` yourself. If verdict is `fail`, send findings back to builder (max 1 round).
+7. Spawn `reviewer` on the final diff. If BLOCK, send notes to builder (max 1 round — reviewer-blocked fixes should be small).
+8. If approved: commit, push the worktree branch, run `gh pr create` with reviewer's description.
+9. If any agent escalates or exceeds retry budget, stop and summarize state.

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -5,7 +5,13 @@
       "Bash(cp /Users/nik/workplace/agent-team-starter/.claude/agents/critic.md ~/.claude/agents/critic.md)",
       "Bash(cp /Users/nik/workplace/agent-team-starter/.claude/agents/builder.md ~/.claude/agents/builder.md)",
       "Bash(cp /Users/nik/workplace/agent-team-starter/.claude/agents/reviewer.md ~/.claude/agents/reviewer.md)",
-      "Bash(cp /Users/nik/workplace/agent-team-starter/.claude/commands/ship.md ~/.claude/commands/ship.md)"
+      "Bash(cp /Users/nik/workplace/agent-team-starter/.claude/commands/ship.md ~/.claude/commands/ship.md)",
+      "Bash(pnpm install *)",
+      "Bash(npm install *)",
+      "Bash(pnpm approve-builds *)",
+      "Bash(git add *)",
+      "Bash(git commit *)",
+      "Bash(git push *)"
     ]
   }
 }

--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json",
+  "entry": ["src/test/setup.ts"],
+  "ignorePatterns": ["dist/**", "public/mockServiceWorker.js", ".claude/**"],
+  "rules": {
+    "unused-files": "error",
+    "unused-exports": "warn",
+    "unused-types": "warn",
+    "circular-dependencies": "error",
+    "unused-dependencies": "warn"
+  },
+  "health": {
+    "maxCyclomatic": 15,
+    "maxCognitive": 12
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ dist
 .claude/worktrees/
 playwright-report/
 test-results/
+*.tsbuildinfo
+.fallow/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "fallow": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["fallow", "mcp"],
+      "env": {}
+    }
+  }
+}

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "plugins": ["typescript", "react", "vitest"],
+  "settings": {
+    "react": {
+      "version": "18"
+    }
+  },
+  "categories": {
+    "correctness": "error",
+    "suspicious": "warn"
+  },
+  "rules": {
+    "no-console": "error",
+    "typescript/no-explicit-any": "error",
+    "typescript/ban-ts-comment": "error",
+    "react-in-jsx-scope": "off"
+  },
+  "ignorePatterns": ["dist/**", "node_modules/**", "public/mockServiceWorker.js"]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,16 @@
 # Definition of Done
 - Green: `pnpm typecheck && pnpm test && pnpm lint && pnpm build`
+- Green: `pnpm fallow audit` verdict is `pass` or `warn` — never `fail` (new dead code, duplication, or complexity regressions block merge)
 - Tests cover: happy path, error path, empty/null, boundary, loading + error states
 - UI changes verified via Chrome DevTools MCP (console clean, network clean, screenshots of happy + error paths attached to PR)
 - No `any`, no `@ts-ignore`, no `console.log`, no `biome-ignore` without a comment
+
+# Codebase intelligence (fallow)
+- Run `pnpm fallow` (or `pnpm fallow audit`) after every implementation to catch dead code, duplication, and complexity regressions
+- `fallow audit` scopes to changed files automatically — it is the CI gate for each PR
+- `fallow dead-code --production` before deleting anything — confirm the candidate is genuinely unreachable
+- `fallow health --targets` to find the highest-priority refactor targets when complexity is increasing
+- Fallow MCP tools are available to agents: use `fallow_dead_code`, `fallow_health`, `fallow_audit` instead of running the CLI when inside an agentic loop
 
 # Stack
 - React 18+ with TypeScript strict mode

--- a/biome.json
+++ b/biome.json
@@ -3,15 +3,8 @@
   "files": {
     "ignore": ["public/mockServiceWorker.js", "dist/**"]
   },
-  "organizeImports": {
-    "enabled": true
-  },
-  "linter": {
-    "enabled": true,
-    "rules": {
-      "recommended": true
-    }
-  },
+  "organizeImports": { "enabled": true },
+  "linter": { "enabled": false },
   "formatter": {
     "enabled": true,
     "indentStyle": "space",

--- a/package.json
+++ b/package.json
@@ -6,41 +6,62 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "lint": "biome check .",
-    "typecheck": "tsc --noEmit",
+    "lint": "oxlint src --config .oxlintrc.json",
+    "lint:ts": "tsgolint src",
+    "format": "biome format --write .",
+    "format:check": "biome format .",
+    "typecheck": "tsgo --noEmit",
+    "typecheck:tsc": "tsc --noEmit",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "dev:ready": "bash scripts/dev-ready.sh",
-    "dev:stop": "bash scripts/dev-stop.sh"
+    "dev:stop": "bash scripts/dev-stop.sh",
+    "fallow": "fallow",
+    "fallow:audit": "fallow audit",
+    "fallow:dead": "fallow dead-code",
+    "fallow:health": "fallow health"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.62.0",
+    "@tanstack/react-router": "1.168.23",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "@tanstack/react-query": "^5.62.0",
-    "zustand": "^5.0.2",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "zustand": "^5.0.2"
   },
   "pnpm": {
-    "onlyBuiltDependencies": ["@biomejs/biome", "esbuild", "msw"]
+    "onlyBuiltDependencies": [
+      "@biomejs/biome",
+      "@typescript/native-preview",
+      "esbuild",
+      "msw",
+      "oxlint",
+      "oxlint-tsgolint"
+    ],
+    "ignoredBuiltDependencies": ["fallow"]
   },
   "devDependencies": {
-    "vite": "^6.0.5",
-    "@vitejs/plugin-react": "^4.3.4",
-    "typescript": "^5.7.2",
+    "@biomejs/biome": "^1.9.4",
+    "@playwright/test": "^1.49.1",
+    "@tailwindcss/vite": "^4.0.0",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.1.0",
+    "@testing-library/user-event": "^14.5.2",
     "@types/react": "^18.3.17",
     "@types/react-dom": "^18.3.5",
-    "vitest": "^2.1.8",
+    "@typescript/native-preview": "latest",
+    "@vitejs/plugin-react": "^4.3.4",
     "@vitest/coverage-v8": "^2.1.8",
-    "@testing-library/react": "^16.1.0",
-    "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/user-event": "^14.5.2",
+    "fallow": "^2.44.2",
     "jsdom": "^25.0.1",
     "msw": "^2.7.0",
-    "@playwright/test": "^1.49.1",
-    "@biomejs/biome": "^1.9.4",
+    "oxlint": "^1.61.0",
+    "oxlint-tsgolint": "^0.21.1",
     "tailwindcss": "^4.0.0",
-    "@tailwindcss/vite": "^4.0.0"
+    "typescript": "^6.0.3",
+    "vite": "^6.0.5",
+    "vitest": "^2.1.8"
   },
   "msw": {
     "workerDirectory": ["public"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.62.0
         version: 5.99.2(react@18.3.1)
+      '@tanstack/react-router':
+        specifier: 1.168.23
+        version: 1.168.23(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -22,7 +25,7 @@ importers:
         version: 3.25.76
       zustand:
         specifier: ^5.0.2
-        version: 5.0.12(@types/react@18.3.28)(react@18.3.1)
+        version: 5.0.12(@types/react@18.3.28)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
     devDependencies:
       '@biomejs/biome':
         specifier: ^1.9.4
@@ -48,30 +51,42 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.5
         version: 18.3.7(@types/react@18.3.28)
+      '@typescript/native-preview':
+        specifier: latest
+        version: 7.0.0-dev.20260422.1
       '@vitejs/plugin-react':
         specifier: ^4.3.4
         version: 4.7.0(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0))
       '@vitest/coverage-v8':
         specifier: ^2.1.8
-        version: 2.1.9(vitest@2.1.9(@types/node@25.6.0)(jsdom@25.0.1)(lightningcss@1.32.0)(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3)))
+        version: 2.1.9(vitest@2.1.9(@types/node@25.6.0)(jsdom@25.0.1)(lightningcss@1.32.0)(msw@2.13.4(@types/node@25.6.0)(typescript@6.0.3)))
+      fallow:
+        specifier: ^2.44.2
+        version: 2.44.2
       jsdom:
         specifier: ^25.0.1
         version: 25.0.1
       msw:
         specifier: ^2.7.0
-        version: 2.13.4(@types/node@25.6.0)(typescript@5.9.3)
+        version: 2.13.4(@types/node@25.6.0)(typescript@6.0.3)
+      oxlint:
+        specifier: ^1.61.0
+        version: 1.61.0(oxlint-tsgolint@0.21.1)
+      oxlint-tsgolint:
+        specifier: ^0.21.1
+        version: 0.21.1
       tailwindcss:
         specifier: ^4.0.0
         version: 4.2.4
       typescript:
-        specifier: ^5.7.2
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vite:
         specifier: ^6.0.5
         version: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@25.6.0)(jsdom@25.0.1)(lightningcss@1.32.0)(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3))
+        version: 2.1.9(@types/node@25.6.0)(jsdom@25.0.1)(lightningcss@1.32.0)(msw@2.13.4(@types/node@25.6.0)(typescript@6.0.3))
 
 packages:
 
@@ -554,6 +569,41 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@fallow-cli/darwin-arm64@2.44.2':
+    resolution: {integrity: sha512-dymI+PKdJw+O/iarHkGStAxm9HpSm4NHpgUXMdZ0QmiVIGRaMdHQQg/gMrCCsQwQ0FFkHBT6JcdtckcaSg3hGA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@fallow-cli/darwin-x64@2.44.2':
+    resolution: {integrity: sha512-ZLbdnAmiYl+ofP+tHozZJmzfkSHNvwtvnENTADIjdPUsr+JnYZtrGV+g7LeBp+5p2tG5z5MBxcv1jote+rIfOQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@fallow-cli/linux-arm64-gnu@2.44.2':
+    resolution: {integrity: sha512-nqswT6A+p/rWpGhlVGw3+T5JalGglKeAdyYKQvwiFa+Drd79u4k2wpe9TZ3wNSG1IN3Sof9TYEkeUskDojgWrw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@fallow-cli/linux-arm64-musl@2.44.2':
+    resolution: {integrity: sha512-5vM0ahJTxzE+p75ZpJ3XNgSyHFJP/LLGKcSRukFOtZssglYoHe5mh7aNzB73VRnhGI2gZn07Lbur4ZYhOTzF7Q==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@fallow-cli/linux-x64-gnu@2.44.2':
+    resolution: {integrity: sha512-ESfdp2YC9QOKAgOWjQZ/n+lVlBAFq+4PtAKpQ6yp/X6Y3zQm20Dg5acEPJtN/XLdcIFGedlQH1Bray2Blo5uhQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@fallow-cli/linux-x64-musl@2.44.2':
+    resolution: {integrity: sha512-ht4CvOtBDR9oi0tlZMsqTcPT6rprjSI9Na//x9tLp8WKyiv96R31PAA+8X3mWxrUTh/C4pgusnOLsr4/NvxAQw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@fallow-cli/win32-x64-msvc@2.44.2':
+    resolution: {integrity: sha512-zZu30X3xSae+o4rbMr1LkHTPVUbuM1P7ScTZRKzBRdaReM4oPYy6g58kp0kVxxQ/Z3hFG5+5tVKxhSMu1yfi1Q==}
+    cpu: [x64]
+    os: [win32]
+
   '@inquirer/ansi@2.0.5':
     resolution: {integrity: sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
@@ -628,6 +678,158 @@ packages:
 
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
+
+  '@oxlint-tsgolint/darwin-arm64@0.21.1':
+    resolution: {integrity: sha512-7TLjyWe4wG9saJc992VWmaHq2hwKfOEEVTjheReXJXaDhavMZI4X9a6nKhbEng4IVkYtzjD2jw16vw2WFXLYLw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint-tsgolint/darwin-x64@0.21.1':
+    resolution: {integrity: sha512-7wf9Wf75nTzA7zpL9myhFe2RKvfuqGUOADNvUooCjEWvh7hmPz3lSEqTMh5Z/VQhzsG04mM9ACyghxhRzq7zFw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint-tsgolint/linux-arm64@0.21.1':
+    resolution: {integrity: sha512-IPuQN/Vd0Rjklg/cCGBbQyUuRBp2f6LQXpZYwk5ivOR6V/+CgiYsv8pn/PVY7gjeyoNvPQrXB7xMjHUO2YZbdw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxlint-tsgolint/linux-x64@0.21.1':
+    resolution: {integrity: sha512-d1niGuTbh2qiv7dR7tqkbOcM5cIR63of0lMBFdEQavL1KrJV8zuRdwdi68K7MNGdgoR+J5A9ajpGGvsHwp1bPg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxlint-tsgolint/win32-arm64@0.21.1':
+    resolution: {integrity: sha512-ICu9y2JLnFPvFqstnWPPNqBM8LK8BWw2OTeaR0UgEMm4hOSbrZAKv1/hwZYyiLqnCNjBL87AGSQIgTHCYlsipw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint-tsgolint/win32-x64@0.21.1':
+    resolution: {integrity: sha512-cTEFCFjCj6iXfrSHcvajSPNqhEA4TxSzU3gFxbdGSAUTNXGToU99IbdhWAPSbhcucoym0XE4Zl7E41NiSkNTug==}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxlint/binding-android-arm-eabi@1.61.0':
+    resolution: {integrity: sha512-6eZBPgiigK5txqoVgRqxbaxiom4lM8AP8CyKPPvpzKnQ3iFRFOIDc+0AapF+qsUSwjOzr5SGk4SxQDpQhkSJMQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxlint/binding-android-arm64@1.61.0':
+    resolution: {integrity: sha512-CkwLR69MUnyv5wjzebvbbtTSUwqLxM35CXE79bHqDIK+NtKmPEUpStTcLQRZMCo4MP0qRT6TXIQVpK0ZVScnMA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxlint/binding-darwin-arm64@1.61.0':
+    resolution: {integrity: sha512-8JbefTkbmvqkqWjmQrHke+MdpgT2UghhD/ktM4FOQSpGeCgbMToJEKdl9zwhr/YWTl92i4QI1KiTwVExpcUN8A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint/binding-darwin-x64@1.61.0':
+    resolution: {integrity: sha512-uWpoxDT47hTnDLcdEh5jVbso8rlTTu5o0zuqa9J8E0JAKmIWn7kGFEIB03Pycn2hd2vKxybPGLhjURy/9We5FQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint/binding-freebsd-x64@1.61.0':
+    resolution: {integrity: sha512-K/o4hEyW7flfMel0iBVznmMBt7VIMHGdjADocHKpK1DUF9erpWnJ+BSSWd2W0c8K3mPtpph+CuHzRU6CI3l9jQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.61.0':
+    resolution: {integrity: sha512-P6040ZkcyweJ0Po9yEFqJCdvZnf3VNCGs1SIHgXDf8AAQNC6ID/heXQs9iSgo2FH7gKaKq32VWc59XZwL34C5Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm-musleabihf@1.61.0':
+    resolution: {integrity: sha512-bwxrGCzTZkuB+THv2TQ1aTkVEfv5oz8sl+0XZZCpoYzErJD8OhPQOTA0ENPd1zJz8QsVdSzSrS2umKtPq4/JXg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm64-gnu@1.61.0':
+    resolution: {integrity: sha512-vkhb9/wKguMkLlrm3FoJW/Xmdv31GgYAE+x8lxxQ+7HeOxXUySI0q36a3NTVIuQUdLzxCI1zzMGsk1o37FOe3w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-arm64-musl@1.61.0':
+    resolution: {integrity: sha512-bl1dQh8LnVqsj6oOQAcxwbuOmNJkwc4p6o//HTBZhNTzJy21TLDwAviMqUFNUxDHkPGpmdKTSN4tWTjLryP8xg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-linux-ppc64-gnu@1.61.0':
+    resolution: {integrity: sha512-QoOX6KB2IiEpyOj/HKqaxi+NQHPnOgNgnr22n9N4ANJCzXkUlj1UmeAbFb4PpqdlHIzvGDM5xZ0OKtcLq9RhiQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-riscv64-gnu@1.61.0':
+    resolution: {integrity: sha512-1TGcTerjY6p152wCof3oKElccq3xHljS/Mucp04gV/4ATpP6nO7YNnp7opEg6SHkv2a57/b4b8Ndm9znJ1/qAw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-riscv64-musl@1.61.0':
+    resolution: {integrity: sha512-65wXEmZIrX2ADwC8i/qFL4EWLSbeuBpAm3suuX1vu4IQkKd+wLT/HU/BOl84kp91u2SxPkPDyQgu4yrqp8vwVA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-linux-s390x-gnu@1.61.0':
+    resolution: {integrity: sha512-TVvhgMvor7Qa6COeXxCJ7ENOM+lcAOGsQ0iUdPSCv2hxb9qSHLQ4XF1h50S6RE1gBOJ0WV3rNukg4JJJP1LWRA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-x64-gnu@1.61.0':
+    resolution: {integrity: sha512-SjpS5uYuFoDnDdZPwZE59ndF95AsY47R5MliuneTWR1pDm2CxGJaYXbKULI71t5TVfLQUWmrHEGRL9xvuq6dnA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-x64-musl@1.61.0':
+    resolution: {integrity: sha512-gGfAeGD4sNJGILZbc/yKcIimO9wQnPMoYp9swAaKeEtwsSQAbU+rsdQze5SBtIP6j0QDzeYd4XSSUCRCF+LIeQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-openharmony-arm64@1.61.0':
+    resolution: {integrity: sha512-OlVT0LrG/ct33EVtWRyR+B/othwmDWeRxfi13wUdPeb3lAT5TgTcFDcfLfarZtzB4W1nWF/zICMgYdkggX2WmQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxlint/binding-win32-arm64-msvc@1.61.0':
+    resolution: {integrity: sha512-vI//NZPJk6DToiovPtaiwD4iQ7kO1r5ReWQD0sOOyKRtP3E2f6jxin4uvwi3OvDzHA2EFfd7DcZl5dtkQh7g1w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint/binding-win32-ia32-msvc@1.61.0':
+    resolution: {integrity: sha512-0ySj4/4zd2XjePs3XAQq7IigIstN4LPQZgCyigX5/ERMLjdWAJfnxcTsrtxZxuij8guJW8foXuHmhGxW0H4dDA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxlint/binding-win32-x64-msvc@1.61.0':
+    resolution: {integrity: sha512-0xgSiyeqDLDZxXoe9CVJrOx3TUVsfyoOY7cNi03JbItNcC9WCZqrSNdrAbHONxhSPaVh/lzfnDcON1RqSUMhHw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -873,6 +1075,10 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
+  '@tanstack/history@1.161.6':
+    resolution: {integrity: sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg==}
+    engines: {node: '>=20.19'}
+
   '@tanstack/query-core@5.99.2':
     resolution: {integrity: sha512-1HunU0bXVsR1ZJMZbcOPE6VtaBJxsW809RE9xPe4Gz7MlB0GWwQvuTPhMoEmQ/hIzFKJ/DWAuttIe7BOaWx0tA==}
 
@@ -880,6 +1086,27 @@ packages:
     resolution: {integrity: sha512-vM91UEe45QUS9ED6OklsVL15i8qKcRqNwpWzPTVWvRPRSEgDudDgHpvyTjcdlwHcrKNa80T+xXYcchT2noPnZA==}
     peerDependencies:
       react: ^18 || ^19
+
+  '@tanstack/react-router@1.168.23':
+    resolution: {integrity: sha512-+GblieDnutG6oipJJPNtRJjrWF8QTZEG/l0532+BngFkVK48oHNOcvIkSoAFYftK1egAwM7KBxXsb0Ou+X6/MQ==}
+    engines: {node: '>=20.19'}
+    peerDependencies:
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
+
+  '@tanstack/react-store@0.9.3':
+    resolution: {integrity: sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/router-core@1.168.15':
+    resolution: {integrity: sha512-Wr0424NDtD8fT/uALobMZ9DdcfsTyXtW5IPR++7zvW8/7RaIOeaqXpVDId8ywaGtqPWLWOfaUg2zUtYtukoXYA==}
+    engines: {node: '>=20.19'}
+    hasBin: true
+
+  '@tanstack/store@0.9.3':
+    resolution: {integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -947,6 +1174,45 @@ packages:
 
   '@types/statuses@2.0.6':
     resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260422.1':
+    resolution: {integrity: sha512-W/lGgoEfbdI/QWYqcNP0fSa4DHQKKEMLzDPsE6fA64zmfCNsTO9M7ttK0acKiLsGB16pr0lubuMDRNN5kXyQ8w==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260422.1':
+    resolution: {integrity: sha512-6tZ2yAcKLBIghwKyC74vDqb/7rB99fTpERv9f64iA1tMh6l+WHIuQb6z3mIFVOYBIl2pN9CYasURLroKYtUz1w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260422.1':
+    resolution: {integrity: sha512-7HL4E7kP0ociYB8R4+QuIbzfT3pjdesNY+ax/q6fP3IMd3/QNAL/qsm/NaokjXke+I7uYxKqQ8Qo/t5MSv/r+A==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260422.1':
+    resolution: {integrity: sha512-EWP1Jq2I8MMSkoF9D6ztXgRmnUy2KcaZfL9FYcdm3Am6ZYuI6/SCR3HVIVYbaixAJXe/qUh5MN3LzJbl/4hefQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260422.1':
+    resolution: {integrity: sha512-fDqkLf2Hv7X1Cy1B5OMcljPt/+8GpnTxFM9rDCFrYAPgOolIQJ9qwkb+xGfvAtxkkE5sZIvGPcqjP9PWQHt2qw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260422.1':
+    resolution: {integrity: sha512-l1tDnyNQSqxFkKz683dD8EORQtcQqZyWkTDnRtHmaPg2mTRxhxSekL/HcsHx/1/DoGTfl310O+CmXzd2mTq3pQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260422.1':
+    resolution: {integrity: sha512-VQbDQlp1bjV5nnHagQLXQAhid3S48l1OToIBjvqlw18s0V0YSgoyNL6E/rE7FBdkGrTLf/rtKjo42IZnt3tvqA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/native-preview@7.0.0-dev.20260422.1':
+    resolution: {integrity: sha512-8CR8zHFlLpSL5OXY4Wbz2DmiDOoat1JBMkydZUHwQIS4cpoTN7SHjk2BN8i51XHUy0jMF5airL0TlY3GOfZmKg==}
+    hasBin: true
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -1095,6 +1361,9 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie-es@3.1.1:
+    resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
+
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
@@ -1214,6 +1483,11 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  fallow@2.44.2:
+    resolution: {integrity: sha512-qaY4THQuq58qbC/w6P0hvUI3jc1sSR6WSFm1P1//W+3r7e12fyH+ZvuEdiqW/moeuJI2YQM+wNW/mpvrxukHjw==}
+    engines: {node: '>=16'}
+    hasBin: true
 
   fast-string-truncated-width@3.0.3:
     resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
@@ -1337,6 +1611,10 @@ packages:
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  isbot@5.1.39:
+    resolution: {integrity: sha512-obH0yYahGXdzNxo+djmHhBYThUKDkz565cxkIlt2L9hXfv1NlaLKoDBHo6KxXsYrIXx2RK3x5vY36CfZcobxEw==}
+    engines: {node: '>=18'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -1546,6 +1824,20 @@ packages:
   outvariant@1.4.3:
     resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
 
+  oxlint-tsgolint@0.21.1:
+    resolution: {integrity: sha512-O2hxiT14C2HJkwzBU6CQBFPoagSd/IcV+Tt3e3UUaXFwbW4BO5DSDPSSboc3UM5MIDY+MLyepvtQwBQafNxWdw==}
+    hasBin: true
+
+  oxlint@1.61.0:
+    resolution: {integrity: sha512-ZC0ALuhDZ6ivOFG+sy0D0pEDN49EvsId98zVlmYdkcXHsEM14m/qTNUEsUpiFiCVbpIxYtVBmmLE87nsbUHohQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      oxlint-tsgolint: '>=0.18.0'
+    peerDependenciesMeta:
+      oxlint-tsgolint:
+        optional: true
+
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
@@ -1655,6 +1947,16 @@ packages:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  seroval-plugins@1.5.2:
+    resolution: {integrity: sha512-qpY0Cl+fKYFn4GOf3cMiq6l72CpuVaawb6ILjubOQ+diJ54LfOWaSSPsaswN8DRPIPW4Yq+tE1k5aKd7ILyaFg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      seroval: ^1.0
+
+  seroval@1.5.2:
+    resolution: {integrity: sha512-xcRN39BdsnO9Tf+VzsE7b3JyTJASItIV1FVFewJKCFcW4s4haIKS3e6vj8PGB9qBwC7tnuOywQMdv5N4qkzi7Q==}
+    engines: {node: '>=10'}
 
   set-cookie-parser@3.1.0:
     resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
@@ -1785,8 +2087,8 @@ packages:
     resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
     engines: {node: '>=20'}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -1801,6 +2103,11 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   vite-node@2.1.9:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
@@ -2332,6 +2639,27 @@ snapshots:
   '@esbuild/win32-x64@0.25.12':
     optional: true
 
+  '@fallow-cli/darwin-arm64@2.44.2':
+    optional: true
+
+  '@fallow-cli/darwin-x64@2.44.2':
+    optional: true
+
+  '@fallow-cli/linux-arm64-gnu@2.44.2':
+    optional: true
+
+  '@fallow-cli/linux-arm64-musl@2.44.2':
+    optional: true
+
+  '@fallow-cli/linux-x64-gnu@2.44.2':
+    optional: true
+
+  '@fallow-cli/linux-x64-musl@2.44.2':
+    optional: true
+
+  '@fallow-cli/win32-x64-msvc@2.44.2':
+    optional: true
+
   '@inquirer/ansi@2.0.5': {}
 
   '@inquirer/confirm@6.0.12(@types/node@25.6.0)':
@@ -2408,6 +2736,81 @@ snapshots:
       outvariant: 1.4.3
 
   '@open-draft/until@2.1.0': {}
+
+  '@oxlint-tsgolint/darwin-arm64@0.21.1':
+    optional: true
+
+  '@oxlint-tsgolint/darwin-x64@0.21.1':
+    optional: true
+
+  '@oxlint-tsgolint/linux-arm64@0.21.1':
+    optional: true
+
+  '@oxlint-tsgolint/linux-x64@0.21.1':
+    optional: true
+
+  '@oxlint-tsgolint/win32-arm64@0.21.1':
+    optional: true
+
+  '@oxlint-tsgolint/win32-x64@0.21.1':
+    optional: true
+
+  '@oxlint/binding-android-arm-eabi@1.61.0':
+    optional: true
+
+  '@oxlint/binding-android-arm64@1.61.0':
+    optional: true
+
+  '@oxlint/binding-darwin-arm64@1.61.0':
+    optional: true
+
+  '@oxlint/binding-darwin-x64@1.61.0':
+    optional: true
+
+  '@oxlint/binding-freebsd-x64@1.61.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.61.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-musleabihf@1.61.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-gnu@1.61.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-musl@1.61.0':
+    optional: true
+
+  '@oxlint/binding-linux-ppc64-gnu@1.61.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-gnu@1.61.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-musl@1.61.0':
+    optional: true
+
+  '@oxlint/binding-linux-s390x-gnu@1.61.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-gnu@1.61.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-musl@1.61.0':
+    optional: true
+
+  '@oxlint/binding-openharmony-arm64@1.61.0':
+    optional: true
+
+  '@oxlint/binding-win32-arm64-msvc@1.61.0':
+    optional: true
+
+  '@oxlint/binding-win32-ia32-msvc@1.61.0':
+    optional: true
+
+  '@oxlint/binding-win32-x64-msvc@1.61.0':
+    optional: true
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -2561,12 +2964,39 @@ snapshots:
       tailwindcss: 4.2.4
       vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)
 
+  '@tanstack/history@1.161.6': {}
+
   '@tanstack/query-core@5.99.2': {}
 
   '@tanstack/react-query@5.99.2(react@18.3.1)':
     dependencies:
       '@tanstack/query-core': 5.99.2
       react: 18.3.1
+
+  '@tanstack/react-router@1.168.23(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/history': 1.161.6
+      '@tanstack/react-store': 0.9.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tanstack/router-core': 1.168.15
+      isbot: 5.1.39
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@tanstack/react-store@0.9.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/store': 0.9.3
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      use-sync-external-store: 1.6.0(react@18.3.1)
+
+  '@tanstack/router-core@1.168.15':
+    dependencies:
+      '@tanstack/history': 1.161.6
+      cookie-es: 3.1.1
+      seroval: 1.5.2
+      seroval-plugins: 1.5.2(seroval@1.5.2)
+
+  '@tanstack/store@0.9.3': {}
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -2648,6 +3078,37 @@ snapshots:
 
   '@types/statuses@2.0.6': {}
 
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260422.1':
+    optional: true
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260422.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260422.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260422.1':
+    optional: true
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260422.1':
+    optional: true
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260422.1':
+    optional: true
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260422.1':
+    optional: true
+
+  '@typescript/native-preview@7.0.0-dev.20260422.1':
+    optionalDependencies:
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260422.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260422.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260422.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260422.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260422.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260422.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260422.1
+
   '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0))':
     dependencies:
       '@babel/core': 7.29.0
@@ -2660,7 +3121,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@25.6.0)(jsdom@25.0.1)(lightningcss@1.32.0)(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3)))':
+  '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@25.6.0)(jsdom@25.0.1)(lightningcss@1.32.0)(msw@2.13.4(@types/node@25.6.0)(typescript@6.0.3)))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -2674,7 +3135,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 1.2.0
-      vitest: 2.1.9(@types/node@25.6.0)(jsdom@25.0.1)(lightningcss@1.32.0)(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3))
+      vitest: 2.1.9(@types/node@25.6.0)(jsdom@25.0.1)(lightningcss@1.32.0)(msw@2.13.4(@types/node@25.6.0)(typescript@6.0.3))
     transitivePeerDependencies:
       - supports-color
 
@@ -2685,13 +3146,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.9(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3))(vite@5.4.21(@types/node@25.6.0)(lightningcss@1.32.0))':
+  '@vitest/mocker@2.1.9(msw@2.13.4(@types/node@25.6.0)(typescript@6.0.3))(vite@5.4.21(@types/node@25.6.0)(lightningcss@1.32.0))':
     dependencies:
       '@vitest/spy': 2.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      msw: 2.13.4(@types/node@25.6.0)(typescript@5.9.3)
+      msw: 2.13.4(@types/node@25.6.0)(typescript@6.0.3)
       vite: 5.4.21(@types/node@25.6.0)(lightningcss@1.32.0)
 
   '@vitest/pretty-format@2.1.9':
@@ -2803,6 +3264,8 @@ snapshots:
       delayed-stream: 1.0.0
 
   convert-source-map@2.0.0: {}
+
+  cookie-es@3.1.1: {}
 
   cookie@1.1.1: {}
 
@@ -2945,6 +3408,18 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  fallow@2.44.2:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      '@fallow-cli/darwin-arm64': 2.44.2
+      '@fallow-cli/darwin-x64': 2.44.2
+      '@fallow-cli/linux-arm64-gnu': 2.44.2
+      '@fallow-cli/linux-arm64-musl': 2.44.2
+      '@fallow-cli/linux-x64-gnu': 2.44.2
+      '@fallow-cli/linux-x64-musl': 2.44.2
+      '@fallow-cli/win32-x64-msvc': 2.44.2
+
   fast-string-truncated-width@3.0.3: {}
 
   fast-string-width@3.0.2:
@@ -3065,6 +3540,8 @@ snapshots:
   is-node-process@1.2.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
+
+  isbot@5.1.39: {}
 
   isexe@2.0.0: {}
 
@@ -3230,7 +3707,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3):
+  msw@2.13.4(@types/node@25.6.0)(typescript@6.0.3):
     dependencies:
       '@inquirer/confirm': 6.0.12(@types/node@25.6.0)
       '@mswjs/interceptors': 0.41.4
@@ -3251,7 +3728,7 @@ snapshots:
       until-async: 3.0.2
       yargs: 17.7.2
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - '@types/node'
 
@@ -3264,6 +3741,38 @@ snapshots:
   nwsapi@2.2.23: {}
 
   outvariant@1.4.3: {}
+
+  oxlint-tsgolint@0.21.1:
+    optionalDependencies:
+      '@oxlint-tsgolint/darwin-arm64': 0.21.1
+      '@oxlint-tsgolint/darwin-x64': 0.21.1
+      '@oxlint-tsgolint/linux-arm64': 0.21.1
+      '@oxlint-tsgolint/linux-x64': 0.21.1
+      '@oxlint-tsgolint/win32-arm64': 0.21.1
+      '@oxlint-tsgolint/win32-x64': 0.21.1
+
+  oxlint@1.61.0(oxlint-tsgolint@0.21.1):
+    optionalDependencies:
+      '@oxlint/binding-android-arm-eabi': 1.61.0
+      '@oxlint/binding-android-arm64': 1.61.0
+      '@oxlint/binding-darwin-arm64': 1.61.0
+      '@oxlint/binding-darwin-x64': 1.61.0
+      '@oxlint/binding-freebsd-x64': 1.61.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.61.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.61.0
+      '@oxlint/binding-linux-arm64-gnu': 1.61.0
+      '@oxlint/binding-linux-arm64-musl': 1.61.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.61.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.61.0
+      '@oxlint/binding-linux-riscv64-musl': 1.61.0
+      '@oxlint/binding-linux-s390x-gnu': 1.61.0
+      '@oxlint/binding-linux-x64-gnu': 1.61.0
+      '@oxlint/binding-linux-x64-musl': 1.61.0
+      '@oxlint/binding-openharmony-arm64': 1.61.0
+      '@oxlint/binding-win32-arm64-msvc': 1.61.0
+      '@oxlint/binding-win32-ia32-msvc': 1.61.0
+      '@oxlint/binding-win32-x64-msvc': 1.61.0
+      oxlint-tsgolint: 0.21.1
 
   package-json-from-dist@1.0.1: {}
 
@@ -3382,6 +3891,12 @@ snapshots:
 
   semver@7.7.4: {}
 
+  seroval-plugins@1.5.2(seroval@1.5.2):
+    dependencies:
+      seroval: 1.5.2
+
+  seroval@1.5.2: {}
+
   set-cookie-parser@3.1.0: {}
 
   shebang-command@2.0.0:
@@ -3489,7 +4004,7 @@ snapshots:
     dependencies:
       tagged-tag: 1.0.0
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
   undici-types@7.19.2: {}
 
@@ -3500,6 +4015,10 @@ snapshots:
       browserslist: 4.28.2
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  use-sync-external-store@1.6.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   vite-node@2.1.9(@types/node@25.6.0)(lightningcss@1.32.0):
     dependencies:
@@ -3543,10 +4062,10 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.32.0
 
-  vitest@2.1.9(@types/node@25.6.0)(jsdom@25.0.1)(lightningcss@1.32.0)(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3)):
+  vitest@2.1.9(@types/node@25.6.0)(jsdom@25.0.1)(lightningcss@1.32.0)(msw@2.13.4(@types/node@25.6.0)(typescript@6.0.3)):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3))(vite@5.4.21(@types/node@25.6.0)(lightningcss@1.32.0))
+      '@vitest/mocker': 2.1.9(msw@2.13.4(@types/node@25.6.0)(typescript@6.0.3))(vite@5.4.21(@types/node@25.6.0)(lightningcss@1.32.0))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9
@@ -3641,7 +4160,8 @@ snapshots:
 
   zod@3.25.76: {}
 
-  zustand@5.0.12(@types/react@18.3.28)(react@18.3.1):
+  zustand@5.0.12(@types/react@18.3.28)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1)):
     optionalDependencies:
       '@types/react': 18.3.28
       react: 18.3.1
+      use-sync-external-store: 1.6.0(react@18.3.1)

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,37 +1,40 @@
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it } from "vitest";
-import { App } from "./App";
 import { useUiStore } from "./store/uiStore";
-import { renderWithProviders } from "./test/utils";
+import { renderWithRouter } from "./test/utils";
 
 describe("App dark mode", () => {
   beforeEach(() => {
     useUiStore.setState({ darkMode: false });
   });
 
-  it("does not apply the 'dark' class initially", () => {
-    renderWithProviders(<App />);
-    const wrapper = screen.getByTestId("app-root");
-    expect(wrapper).not.toHaveClass("dark");
+  it("does not apply the 'dark' class initially", async () => {
+    renderWithRouter();
+    // Wait for router to settle (redirect fires synchronously but router renders async)
+    await waitFor(() => expect(screen.getByTestId("app-root")).toBeInTheDocument());
+    expect(screen.getByTestId("app-root")).not.toHaveClass("dark");
   });
 
   it("adds the 'dark' class when the toggle button is clicked", async () => {
     const user = userEvent.setup();
-    renderWithProviders(<App />);
-    const button = screen.getByRole("button", { name: /toggle dark mode/i });
-    await user.click(button);
-    const wrapper = screen.getByTestId("app-root");
-    expect(wrapper).toHaveClass("dark");
+    renderWithRouter();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /toggle dark mode/i })).toBeInTheDocument()
+    );
+    await user.click(screen.getByRole("button", { name: /toggle dark mode/i }));
+    expect(screen.getByTestId("app-root")).toHaveClass("dark");
   });
 
   it("removes the 'dark' class when the toggle button is clicked twice", async () => {
     const user = userEvent.setup();
-    renderWithProviders(<App />);
-    const button = screen.getByRole("button", { name: /toggle dark mode/i });
-    await user.click(button);
-    await user.click(button);
-    const wrapper = screen.getByTestId("app-root");
-    expect(wrapper).not.toHaveClass("dark");
+    renderWithRouter();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /toggle dark mode/i })).toBeInTheDocument()
+    );
+    const btn = screen.getByRole("button", { name: /toggle dark mode/i });
+    await user.click(btn);
+    await user.click(btn);
+    expect(screen.getByTestId("app-root")).not.toHaveClass("dark");
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { UsersPage } from "./pages/UsersPage";
+import { Outlet } from "@tanstack/react-router";
 import { useUiStore } from "./store/uiStore";
 
 export function App() {
@@ -28,7 +28,7 @@ export function App() {
         </button>
       </header>
       <main className="p-4">
-        <UsersPage />
+        <Outlet />
       </main>
     </div>
   );

--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -1,14 +1,14 @@
 import { useQuery } from "@tanstack/react-query";
 import { z } from "zod";
 
-export const UserSchema = z.object({
+const UserSchema = z.object({
   id: z.string().uuid(),
   name: z.string(),
   email: z.string().email(),
   role: z.enum(["admin", "member"]),
 });
 
-export const UsersResponseSchema = z.array(UserSchema);
+const UsersResponseSchema = z.array(UserSchema);
 
 export type User = z.infer<typeof UserSchema>;
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,8 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { RouterProvider } from "@tanstack/react-router";
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { App } from "./App";
+import { router } from "./router";
 import "./index.css";
 
 const queryClient = new QueryClient();
@@ -19,7 +20,7 @@ prepare().then(() => {
   ReactDOM.createRoot(root).render(
     <React.StrictMode>
       <QueryClientProvider client={queryClient}>
-        <App />
+        <RouterProvider router={router} />
       </QueryClientProvider>
     </React.StrictMode>
   );

--- a/src/router.test.tsx
+++ b/src/router.test.tsx
@@ -1,0 +1,20 @@
+import { screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useUiStore } from "./store/uiStore";
+import { renderWithRouter } from "./test/utils";
+
+describe("router", () => {
+  beforeEach(() => {
+    useUiStore.setState({ darkMode: false });
+  });
+
+  it("renders UsersPage at /users", async () => {
+    renderWithRouter({ initialPath: "/users" });
+    await waitFor(() => expect(screen.getByText("Alice Admin")).toBeInTheDocument());
+  });
+
+  it("redirects / to /users", async () => {
+    renderWithRouter({ initialPath: "/" });
+    await waitFor(() => expect(screen.getByText("Alice Admin")).toBeInTheDocument());
+  });
+});

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,0 +1,47 @@
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  redirect,
+} from "@tanstack/react-router";
+import { App } from "./App";
+import { UsersPage } from "./pages/UsersPage";
+
+const rootRoute = createRootRoute({ component: App });
+
+const indexRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/",
+  beforeLoad: () => {
+    // Redirect root to /users as the default page
+    // oxlint-disable-next-line consistent-return -- TanStack Router expects thrown redirect, not return value
+    throw redirect({ to: "/users" });
+  },
+});
+
+const usersRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/users",
+  component: UsersPage,
+});
+
+const routeTree = rootRoute.addChildren([indexRoute, usersRoute]);
+
+export function createAppRouter(opts?: { initialPath?: string }) {
+  return createRouter({
+    routeTree,
+    history: opts?.initialPath
+      ? createMemoryHistory({ initialEntries: [opts.initialPath] })
+      : undefined,
+  });
+}
+
+// Singleton for main.tsx production use
+export const router = createAppRouter();
+
+declare module "@tanstack/react-router" {
+  interface Register {
+    router: ReturnType<typeof createAppRouter>;
+  }
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -2,6 +2,10 @@ import "@testing-library/jest-dom/vitest";
 import { afterAll, afterEach, beforeAll } from "vitest";
 import { server } from "../mocks/server";
 
+// jsdom does not implement window.scrollTo — stub it to suppress "not implemented" noise
+// from TanStack Router's scroll-restoration module in tests.
+window.scrollTo = () => {};
+
 beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());

--- a/src/test/utils.tsx
+++ b/src/test/utils.tsx
@@ -1,18 +1,14 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { RouterProvider } from "@tanstack/react-router";
 import { type RenderOptions, type RenderResult, render } from "@testing-library/react";
 import type { ReactElement, ReactNode } from "react";
+import { createAppRouter } from "../router";
 
 export function createTestQueryClient(): QueryClient {
   return new QueryClient({
     defaultOptions: {
-      queries: {
-        retry: 0,
-        gcTime: 0,
-        staleTime: Number.POSITIVE_INFINITY,
-      },
-      mutations: {
-        retry: 0,
-      },
+      queries: { retry: 0, gcTime: 0, staleTime: Number.POSITIVE_INFINITY },
+      mutations: { retry: 0 },
     },
   });
 }
@@ -22,11 +18,25 @@ export function renderWithProviders(
   options?: Omit<RenderOptions, "wrapper"> & { queryClient?: QueryClient }
 ): RenderResult & { queryClient: QueryClient } {
   const queryClient = options?.queryClient ?? createTestQueryClient();
-
   function Wrapper({ children }: { children: ReactNode }) {
     return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
   }
-
   const result = render(ui, { wrapper: Wrapper, ...options });
+  return { ...result, queryClient };
+}
+
+// Renders the full router (App layout + matched route) inside QueryClientProvider.
+// Defaults to /users so the redirect at / does not fire in tests.
+export function renderWithRouter(opts?: {
+  initialPath?: string;
+  queryClient?: QueryClient;
+}): RenderResult & { queryClient: QueryClient } {
+  const queryClient = opts?.queryClient ?? createTestQueryClient();
+  const testRouter = createAppRouter({ initialPath: opts?.initialPath ?? "/users" });
+  const result = render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={testRouter} />
+    </QueryClientProvider>
+  );
   return { ...result, queryClient };
 }


### PR DESCRIPTION
## Summary

- **Tooling:** Switch lint to Oxlint, use `tsgo` for typecheck (with `tsc` available as `typecheck:tsc`), add Fallow (CLI scripts + `.fallowrc.json`), register the Fallow MCP server, and keep Biome for formatting only. Ignore `*.tsbuildinfo` and `.fallow/` in git.
- **Routing:** Add TanStack Router with `/` redirecting to `/users`, shell layout with `<Outlet />`, and tests for router behavior and dark mode through `renderWithRouter`. Stub `window.scrollTo` in tests for jsdom. Reduce unused exports in the users Zod schemas for Fallow.
- **Docs/agents:** Document Fallow as a merge gate in `CLAUDE.md`, add fallow steps to builder/reviewer/ship, and expand local `settings.local.json` allowlist for pnpm/git.

## Test plan

- [ ] `pnpm install`
- [ ] `pnpm test`
- [ ] `pnpm typecheck` (or `./node_modules/.bin/oxlint src --config .oxlintrc.json` if `pnpm lint` misbehaves in your environment)
- [ ] `pnpm dev` — confirm `/` lands on users list and dark mode still works

Made with [Cursor](https://cursor.com)