### PR TITLE
chore: gitignore local SQLite database files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@ playwright-report/
 test-results/
 *.tsbuildinfo
 .fallow/
+
+# SQLite (local dev DB + WAL mode sidecars — regenerate via migrate/seed, do not commit)
+*.sqlite
+*.sqlite-shm
+*.sqlite-wal


### PR DESCRIPTION
## Summary

- Ignore `*.sqlite`, `*.sqlite-shm`, and `*.sqlite-wal` so local dev databases and SQLite WAL mode files are not committed. These should be recreated via migrations or seed scripts.

## Test plan

- [ ] `git status` shows no unwanted sqlite paths after local DB use
- [ ] CI / hooks still pass (no code changes)

Made with [Cursor](https://cursor.com)