### PR TITLE
chore: add shared Cursor MCP config

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,37 @@
+{
+  "mcpServers": {
+    "github": {
+      "url": "https://api.githubcopilot.com/mcp/",
+      "headers": {
+        "Authorization": "Bearer ${env:GITHUB_PERSONAL_ACCESS_TOKEN}"
+      }
+    },
+    "chrome-devtools": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "chrome-devtools-mcp@latest",
+        "--no-usage-statistics"
+      ]
+    },
+    "filesystem": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "${workspaceFolder}"
+      ]
+    },
+    "sequential-thinking": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
+    },
+    "memory": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-memory"],
+      "env": {
+        "MEMORY_FILE_PATH": "${workspaceFolder}/.cursor/mcp-memory.jsonl"
+      }
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ playwright-report/
 test-results/
 *.tsbuildinfo
 .fallow/
+.cursor/mcp-memory.jsonl
 
 # SQLite (local dev DB + WAL mode sidecars — regenerate via migrate/seed, do not commit)
 *.sqlite


### PR DESCRIPTION
## Summary

- Add `.cursor/mcp.json` with optional MCP servers: GitHub (PAT via `GITHUB_PERSONAL_ACCESS_TOKEN`), Chrome DevTools, filesystem, sequential thinking, and memory. Uses `${env:...}` and `${workspaceFolder}` so secrets are not in the repo.
- Ignore `.cursor/mcp-memory.jsonl` for the local knowledge-graph file.

## Test plan

- [x] `pnpm test` (no runtime change to app)
- [ ] Restart Cursor; confirm MCP servers load; set `GITHUB_PERSONAL_ACCESS_TOKEN` in environment for GitHub tools

Made with [Cursor](https://cursor.com)