### PR TITLE
fix(ui): hover feedback for Edit and dashboard icon buttons

### DIFF
--- a/src/components/UserCard.tsx
+++ b/src/components/UserCard.tsx
@@ -44,125 +44,134 @@ export function UserCard({ user }: UserCardProps) {
 
   if (editing) {
     return (
-        <form
-          onSubmit={(e) => {
-            void onSave(e);
-          }}
-          className="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800"
-          aria-label={`Edit user ${user.name}`}
-        >
-          <div className="grid gap-2 sm:grid-cols-2">
-            <div>
-              <label htmlFor={`edit-name-${user.id}`} className="mb-0.5 block text-xs text-gray-600 dark:text-gray-400">
-                Name
-              </label>
-              <input
-                id={`edit-name-${user.id}`}
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                required
-                className="w-full rounded border border-gray-300 px-2 py-1 text-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white"
-              />
-            </div>
-            <div>
-              <label htmlFor={`edit-email-${user.id}`} className="mb-0.5 block text-xs text-gray-600 dark:text-gray-400">
-                Email
-              </label>
-              <input
-                id={`edit-email-${user.id}`}
-                type="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                required
-                className="w-full rounded border border-gray-300 px-2 py-1 text-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white"
-              />
-            </div>
-            <div>
-              <label htmlFor={`edit-role-${user.id}`} className="mb-0.5 block text-xs text-gray-600 dark:text-gray-400">
-                Role
-              </label>
-              <select
-                id={`edit-role-${user.id}`}
-                value={role}
-                onChange={(e) => setRole(e.target.value as "admin" | "member")}
-                className="w-full rounded border border-gray-300 px-2 py-1 text-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white"
-              >
-                <option value="member">member</option>
-                <option value="admin">admin</option>
-              </select>
-            </div>
-          </div>
-          {updateUser.error ? (
-            <p role="alert" className="mt-2 text-sm text-red-600 dark:text-red-400">
-              {updateUser.error instanceof Error ? updateUser.error.message : "Update failed."}
-            </p>
-          ) : null}
-          <div className="mt-3 flex flex-wrap gap-2">
-            <button
-              type="submit"
-              disabled={updateUser.isPending}
-              className="rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
+      <form
+        onSubmit={(e) => {
+          void onSave(e);
+        }}
+        className="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800"
+        aria-label={`Edit user ${user.name}`}
+      >
+        <div className="grid gap-2 sm:grid-cols-2">
+          <div>
+            <label
+              htmlFor={`edit-name-${user.id}`}
+              className="mb-0.5 block text-xs text-gray-600 dark:text-gray-400"
             >
-              {updateUser.isPending ? "Saving…" : "Save"}
-            </button>
-            <button
-              type="button"
-              onClick={() => {
-                updateUser.reset();
-                setEditing(false);
-                setName(user.name);
-                setEmail(user.email);
-                setRole(user.role);
-              }}
-              className="rounded border border-gray-300 px-3 py-1 text-sm dark:border-gray-600"
-            >
-              Cancel
-            </button>
+              Name
+            </label>
+            <input
+              id={`edit-name-${user.id}`}
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              className="w-full rounded border border-gray-300 px-2 py-1 text-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white"
+            />
           </div>
-        </form>
+          <div>
+            <label
+              htmlFor={`edit-email-${user.id}`}
+              className="mb-0.5 block text-xs text-gray-600 dark:text-gray-400"
+            >
+              Email
+            </label>
+            <input
+              id={`edit-email-${user.id}`}
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              className="w-full rounded border border-gray-300 px-2 py-1 text-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white"
+            />
+          </div>
+          <div>
+            <label
+              htmlFor={`edit-role-${user.id}`}
+              className="mb-0.5 block text-xs text-gray-600 dark:text-gray-400"
+            >
+              Role
+            </label>
+            <select
+              id={`edit-role-${user.id}`}
+              value={role}
+              onChange={(e) => setRole(e.target.value as "admin" | "member")}
+              className="w-full rounded border border-gray-300 px-2 py-1 text-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white"
+            >
+              <option value="member">member</option>
+              <option value="admin">admin</option>
+            </select>
+          </div>
+        </div>
+        {updateUser.error ? (
+          <p role="alert" className="mt-2 text-sm text-red-600 dark:text-red-400">
+            {updateUser.error instanceof Error ? updateUser.error.message : "Update failed."}
+          </p>
+        ) : null}
+        <div className="mt-3 flex flex-wrap gap-2">
+          <button
+            type="submit"
+            disabled={updateUser.isPending}
+            className="rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            {updateUser.isPending ? "Saving…" : "Save"}
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              updateUser.reset();
+              setEditing(false);
+              setName(user.name);
+              setEmail(user.email);
+              setRole(user.role);
+            }}
+            className="rounded border border-gray-300 px-3 py-1 text-sm hover:bg-gray-100 dark:border-gray-600 dark:hover:bg-gray-700"
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
     );
   }
 
   return (
-      <div className="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-          <div>
-            <p className="font-medium">{user.name}</p>
-            <p className="text-sm text-gray-500 dark:text-gray-400">{user.email}</p>
-          </div>
-          <div className="flex flex-wrap items-center gap-2">
-            <span
-              data-testid="user-role"
-              className={
-                user.role === "admin"
-                  ? "rounded-full bg-purple-100 px-2 py-0.5 text-xs text-purple-800 dark:bg-purple-900 dark:text-purple-200"
-                  : "rounded-full bg-blue-100 px-2 py-0.5 text-xs text-blue-800 dark:bg-blue-900 dark:text-blue-200"
-              }
-            >
-              {user.role}
-            </span>
-            <button
-              type="button"
-              onClick={() => setEditing(true)}
-              className="rounded border border-gray-300 px-2 py-1 text-sm dark:border-gray-600"
-            >
-              Edit
-            </button>
-            <button
-              type="button"
-              onClick={() => onDelete()}
-              disabled={deleteUser.isPending}
-              className="rounded border border-red-300 px-2 py-1 text-sm text-red-700 hover:bg-red-50 disabled:opacity-50 dark:border-red-800 dark:text-red-300 dark:hover:bg-red-950"
-            >
-              {deleteUser.isPending ? "…" : "Delete"}
-            </button>
-          </div>
+    <div className="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <p className="font-medium">{user.name}</p>
+          <p className="text-sm text-gray-500 dark:text-gray-400">{user.email}</p>
         </div>
-        {deleteUser.error ? (
-          <p role="alert" className="mt-2 text-sm text-red-600 dark:text-red-400">
-            {deleteUser.error instanceof Error ? deleteUser.error.message : "Delete failed."}
-          </p>
-        ) : null}
+        <div className="flex flex-wrap items-center gap-2">
+          <span
+            data-testid="user-role"
+            className={
+              user.role === "admin"
+                ? "rounded-full bg-purple-100 px-2 py-0.5 text-xs text-purple-800 dark:bg-purple-900 dark:text-purple-200"
+                : "rounded-full bg-blue-100 px-2 py-0.5 text-xs text-blue-800 dark:bg-blue-900 dark:text-blue-200"
+            }
+          >
+            {user.role}
+          </span>
+          <button
+            type="button"
+            onClick={() => setEditing(true)}
+            className="rounded border border-gray-300 px-2 py-1 text-sm hover:bg-gray-100 dark:border-gray-600 dark:hover:bg-gray-700"
+          >
+            Edit
+          </button>
+          <button
+            type="button"
+            onClick={() => onDelete()}
+            disabled={deleteUser.isPending}
+            className="rounded border border-red-300 px-2 py-1 text-sm text-red-700 hover:bg-red-50 disabled:opacity-50 dark:border-red-800 dark:text-red-300 dark:hover:bg-red-950"
+          >
+            {deleteUser.isPending ? "…" : "Delete"}
+          </button>
+        </div>
       </div>
+      {deleteUser.error ? (
+        <p role="alert" className="mt-2 text-sm text-red-600 dark:text-red-400">
+          {deleteUser.error instanceof Error ? deleteUser.error.message : "Delete failed."}
+        </p>
+      ) : null}
+    </div>
   );
 }

--- a/src/pages/DashboardDemoPage.tsx
+++ b/src/pages/DashboardDemoPage.tsx
@@ -106,7 +106,7 @@ export function DashboardDemoPage() {
                 type="button"
                 size="icon-sm"
                 variant="ghost"
-                className="size-8"
+                className={cn("size-8", "hover:bg-gray-200/90 dark:hover:bg-gray-700")}
                 aria-label="More"
               >
                 <MoreHorizontal className="size-4" />
@@ -213,7 +213,10 @@ export function DashboardDemoPage() {
                               type="button"
                               size="icon-sm"
                               variant="ghost"
-                              className="size-8"
+                              className={cn(
+                                "size-8",
+                                "hover:bg-gray-200/90 dark:hover:bg-gray-700"
+                              )}
                               aria-label="Row actions"
                             >
                               <MoreHorizontal className="size-4" />


### PR DESCRIPTION
## Summary
- Add neutral hover backgrounds to **Edit** and **Cancel** on `UserCard` (they previously had no hover surface while **Delete** did).
- On **Dashboard demo**, strengthen ghost icon button hover (`gray-200` / `gray-700`) so it reads clearly on table rows that already use `hover:bg-muted/50`.

## Test plan
- `pnpm typecheck && pnpm lint && pnpm test && pnpm build` — green locally
- `pnpm fallow audit` — `pass`

## Verification
- Chrome DevTools MCP not used in this session (no screenshots under `verification/`).
- Manual: hover **Edit** on `/users`; hover **⋯** on `/dashboard-demo` (chart header and team table).

Made with [Cursor](https://cursor.com)