### PR TITLE
docs(ai-rules): rename address-pr-comments skill to fix-comments

### DIFF
--- a/.ai-rules/skills/commit/SKILL.md
+++ b/.ai-rules/skills/commit/SKILL.md
@@ -28,7 +28,7 @@ description: Create commits, push, open PR. Git-only.
 
 - **Split** last bad commit: `git reset --soft HEAD~1`, unstage, recommit in chunks.
 - **Squash** last N: `git reset --soft HEAD~N` then one new commit.
-- **Fixup rebase:** `git commit --fixup` … `GIT_SEQUENCE_EDITOR=true git rebase -i --autosquash <merge-base>` (details in **address-pr-comments** / team docs).
+- **Fixup rebase:** `git commit --fixup` … `GIT_SEQUENCE_EDITOR=true git rebase -i --autosquash <merge-base>` (details in **fix-comments** / team docs).
 
 ## Avoid
 

--- a/.ai-rules/skills/fix-comments/SKILL.md
+++ b/.ai-rules/skills/fix-comments/SKILL.md
@@ -1,11 +1,11 @@
 ---
-name: address-pr-comments
+name: fix-comments
 description: >-
   Address GitHub PR review: gather unresolved feedback, TODO list, implement selected
   items, thread replies. Needs `gh` (and optionally GitHub MCP).
 ---
 
-# Address PR comments
+# Fix PR comments
 
 **Need:** `gh` installed and `gh auth login`. Prefer GitHub MCP when present; else `gh api` / `gh pr`.
 


### PR DESCRIPTION
## Summary

Renames the `address-pr-comments` agent skill to `fix-comments` (shorter `@fix-comments` mention). Updates the commit skill cross-reference for fixup rebase details.

## Test plan

- [x] Pre-commit hooks pass on this branch (Fallow scoped to changed files).
- [x] `.claude/skills` symlink continues to resolve skills from `.ai-rules/skills`.

Made with [Cursor](https://cursor.com)