### PR TITLE
fix(components-demo): load scroll + verify-compare-main workflow

### DIFF
--- a/.ai-rules/commands/verify-compare-main.md
+++ b/.ai-rules/commands/verify-compare-main.md
@@ -1,0 +1,52 @@
+---
+description: Commit UI work, then Chrome DevTools on main vs this branch (paired screenshots + behavior notes)
+argument-hint: [feature-url-path]
+---
+**Purpose:** Capture the **same URL** on **`main`** and on the **current feature branch** so reviewers see baseline vs change (scroll, layout, new controls). Path: $ARGUMENTS (default `/` — use e.g. `/components-demo` when verifying that route).
+
+**Not** a pixel-diff tool: you get **two screenshot sets** plus a **written** comparison. For automated image baselines, use Playwright visual tests separately.
+
+### 0. Preconditions
+
+- **Commit first** if you have local UI/source changes (use the **commit** skill or `git commit`). This flow uses `git checkout` and needs either a **clean** working tree or an explicit **`git stash push -u -m verify-compare-main`** before step 2 (remember `git stash pop` after).
+- Record the feature branch: `FEATURE=$(git branch --show-current)`. If `FEATURE` is `main`, stop — there is nothing to compare.
+
+### 1. Quality gates (on the feature branch, before switching)
+
+`pnpm typecheck && pnpm lint && pnpm build` — fail → stop.
+
+### 2. Capture on `main`
+
+1. `git checkout main` && `git pull` (pull optional if you already track remote `main`).
+2. `pnpm install` if `package.json` / lockfile differs from what you had on the feature branch (otherwise skip).
+3. `pnpm dev:ready` — fail → log tail, `git checkout "$FEATURE"`, `pnpm dev:stop`, stop.
+4. **Chrome DevTools MCP** (read tool JSON first): same Phase 3 steps as **chrome-devtools-verify** for URL $ARGUMENTS — `navigate_page`, `take_snapshot`, `take_screenshot` with **`filePath`** under `verification/<branch-or-ticket>/` using the **`main-`** prefix, e.g. `main-01-load.png`, `main-02-after-interaction.png`. Match viewport (and `fullPage` flag) to what you will use on the branch.
+5. Optional but recommended: **`/ship-report`** on `main` with a `main-…-ship-report.png` name; note **`GET /api/ship-verify`** in network.
+6. `list_console_messages` (`error` + `warn`) for the navigations on this server run.
+7. `pnpm dev:stop`.
+
+### 3. Capture on the feature branch
+
+1. `git checkout "$FEATURE"`.
+2. `pnpm dev:ready` — fail → log tail, stop.
+3. Repeat the same navigations and **the same interactions** (if any) as on `main`; save screenshots with the **`branch-`** prefix, e.g. `branch-01-load.png`, paired with the same numbers as `main-*`.
+4. Optional: **`/ship-report`** → `branch-…-ship-report.png`; confirm ship-verify **200**.
+5. `list_console_messages` for this run.
+6. `pnpm dev:stop`.
+
+### 4. Report (PR or chat) — required
+
+Use a **side-by-side** description:
+
+| # | Main (`main-…`) | Branch (`branch-…`) |
+|---|-----------------|---------------------|
+| 01 | Short sentence: what the user sees (scroll position, broken/missing UI, etc.) | Short sentence: what changed |
+
+Then list **full paths** to every `main-*` and `branch-*` file. Note console/network deltas if relevant.
+
+### 5. Cleanup
+
+- End on **`git checkout "$FEATURE"`** so the repo is back on the feature branch.
+- Always **`pnpm dev:stop`** after each dev server segment, including on errors.
+
+**Rules:** This command edits **git state** only via checkout (and optional stash). It does not implement features. If `main` cannot run (e.g. missing migrations), say so in the report and fall back to single-branch **verify** plus a short explanation.

--- a/.ai-rules/skills/chrome-devtools-verify/SKILL.md
+++ b/.ai-rules/skills/chrome-devtools-verify/SKILL.md
@@ -27,6 +27,21 @@ Cover **happy** path and **error/empty** if relevant; optional narrow viewport (
 
 **Order:** Verify the **changed route or UI** first (navigate → snapshot → **baseline screenshot** → interact → snapshot → **after screenshot** when applicable → console/network for that flow), then run the **ship-report** step above. Do not skip ship-report for “UI-only” PRs—the page is the app’s **ship smoke** surface and catches broken API wiring unrelated to your diff size.
 
+## Compare `main` vs feature branch (paired evidence)
+
+Use when reviewers need **baseline vs change** on the same route (scroll jumps, layout, new UI), not only “current branch looks fine.”
+
+**Orchestration:** Cursor command **`verify-compare-main`** (`.ai-rules/commands/verify-compare-main.md`) — **commit** (or stash) first, run quality gates on the feature branch, then **`git checkout main`** → `dev:ready` → Chrome MCP → `dev:stop` → **`git checkout` feature** → repeat with **identical** URL, viewport, and interactions.
+
+**Naming:** Under `verification/<branch-or-ticket>/`, prefix files so pairs are obvious:
+
+- `main-01-<route>-load.png` / `branch-01-<route>-load.png`
+- Same numbering for optional before/after pairs: `main-02-before-…` / `main-03-after-…` and `branch-02-before-…` / `branch-03-after-…`
+
+**Report:** A short table — **Main** column vs **Branch** column — describing behavior each screenshot shows, then list all paths. This is a **human** diff; automated pixel diff is Playwright territory, not this MCP flow.
+
+**Caveats:** Lockfile or env differences between `main` and the branch can skew the UI; run `pnpm install` when refs diverge. Always return to the feature branch and `dev:stop` when finished.
+
 ## PR images without committing binaries
 
 - Prefer `scripts/pr-comment-verify-gist.sh <PR#> *.png` from repo root (`gh auth` required). `gh gist create` often rejects binaries — the script or **browser** gist upload + raw URL workarounds; commit SHA + `?raw=true` blob URLs are another option (see script comments / older ship docs).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 - `pnpm typecheck && pnpm test && pnpm lint && pnpm build` — green
 - `pnpm fallow audit` — verdict `pass` or `warn` (not `fail`)
 - Tests: happy, error, empty/null, boundaries, loading + error where relevant
-- **UI / routes** (e.g. `src/pages/**`, `src/components/**`, `src/router.ts`, layout, `src/index.css`): when **Chrome DevTools MCP works**, run **chrome-devtools-verify** (console/network, `take_screenshot` + `filePath` under `verification/<branch-or-ticket>/`, `/ship-report` if in scope). If MCP is down, say so in PR **Verification**; Vitest/build still count — not a hard blocker.
+- **UI / routes** (e.g. `src/pages/**`, `src/components/**`, `src/router.ts`, layout, `src/index.css`): when **Chrome DevTools MCP works**, run **chrome-devtools-verify** (console/network, `take_screenshot` + `filePath` under `verification/<branch-or-ticket>/`, `/ship-report` if in scope). For **main vs branch** behavior (e.g. scroll or layout regressions), use **`verify-compare-main`** (`.ai-rules/commands/verify-compare-main.md`) after committing, then describe paired `main-*` / `branch-*` screenshots in the PR. If MCP is down, say so in PR **Verification**; Vitest/build still count — not a hard blocker.
 - **DB / API / schema:** migrations, green tests, live smoke per **drizzle-db-verify** (`pnpm dev:ready`, hit `/api/...`, `pnpm dev:stop`)
 - No `any`, no `@ts-ignore`, no `console.log`, no `biome-ignore` without a reason
 

--- a/src/pages/components-demo/AllComponentsShowcase.tsx
+++ b/src/pages/components-demo/AllComponentsShowcase.tsx
@@ -315,6 +315,8 @@ export function AllComponentsShowcase() {
   const [slider, setSlider] = React.useState([50]);
   const [comboboxValue, setComboboxValue] = React.useState<string | null>(null);
   const [sectionFilter, setSectionFilter] = React.useState("");
+  /** cmdk scrolls the selected item into view on mount — only mount after the user opens this demo. */
+  const [inlineCommandOpen, setInlineCommandOpen] = React.useState(false);
 
   const filteredSections = React.useMemo(() => {
     const q = sectionFilter.trim().toLowerCase();
@@ -693,7 +695,13 @@ export function AllComponentsShowcase() {
 
           <div className="space-y-2">
             <p className="text-sm font-medium">One-time code</p>
-            <InputOTP maxLength={6} value={otp} onChange={setOtp}>
+            <InputOTP
+              maxLength={6}
+              value={otp}
+              onChange={setOtp}
+              autoComplete="off"
+              name="components-demo-otp"
+            >
               <InputOTPGroup>
                 <InputOTPSlot index={0} />
                 <InputOTPSlot index={1} />
@@ -894,31 +902,42 @@ export function AllComponentsShowcase() {
             </ContextMenu>
           </div>
 
-          <div>
-            <p className="mb-2 text-sm font-medium">Command palette (inline surface)</p>
-            <Command className="max-w-lg border shadow-sm">
-              <CommandInput placeholder="Type a command…" />
-              <CommandList>
-                <CommandEmpty>No results.</CommandEmpty>
-                <CommandGroup heading="Suggestions">
-                  <CommandItem>
-                    <CalendarIcon className="size-4" />
-                    Calendar
-                  </CommandItem>
-                  <CommandItem>
-                    <Activity className="size-4" />
-                    Status
-                  </CommandItem>
-                </CommandGroup>
-                <CommandSeparator />
-                <CommandGroup heading="Files">
-                  <CommandItem>
-                    <FileIcon className="size-4" />
-                    README.md
-                  </CommandItem>
-                </CommandGroup>
-              </CommandList>
-            </Command>
+          <div className="max-w-lg space-y-2">
+            <p className="text-sm font-medium">Command palette (inline surface)</p>
+            <Collapsible open={inlineCommandOpen} onOpenChange={setInlineCommandOpen}>
+              <CollapsibleTrigger asChild>
+                <Button type="button" variant="outline" size="sm">
+                  {inlineCommandOpen ? "Hide" : "Show"} inline command
+                </Button>
+              </CollapsibleTrigger>
+              <CollapsibleContent className="mt-3 data-[state=closed]:hidden">
+                {inlineCommandOpen ? (
+                  <Command className="border shadow-sm">
+                    <CommandInput placeholder="Type a command…" />
+                    <CommandList>
+                      <CommandEmpty>No results.</CommandEmpty>
+                      <CommandGroup heading="Suggestions">
+                        <CommandItem>
+                          <CalendarIcon className="size-4" />
+                          Calendar
+                        </CommandItem>
+                        <CommandItem>
+                          <Activity className="size-4" />
+                          Status
+                        </CommandItem>
+                      </CommandGroup>
+                      <CommandSeparator />
+                      <CommandGroup heading="Files">
+                        <CommandItem>
+                          <FileIcon className="size-4" />
+                          README.md
+                        </CommandItem>
+                      </CommandGroup>
+                    </CommandList>
+                  </Command>
+                ) : null}
+              </CollapsibleContent>
+            </Collapsible>
           </div>
 
           <Accordion type="single" collapsible className="w-full max-w-lg border-b">


### PR DESCRIPTION
## Summary

- **Components demo:** Stop the page from jumping to the middle on first load by deferring the inline cmdk `Command` mount until the user opens it, and by turning off OTP-style autocomplete on the demo `InputOTP` field.
- **AI rules:** Add the **`verify-compare-main`** Cursor command and document paired **`main-*` / `branch-*`** screenshots in **chrome-devtools-verify**, with a pointer in **CLAUDE.md** for regression-style UI evidence.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm build`
- [x] `pnpm test`
- [ ] `/components-demo` — load at top; **Show inline command** still reveals the palette
- [ ] Optional: **`/verify-compare-main`** with `/components-demo` for paired shots vs `main`

Made with [Cursor](https://cursor.com)