### PR TITLE
docs(ai-rules): point /ship at lead agent for branch scope

### DIFF
--- a/.ai-rules/README.md
+++ b/.ai-rules/README.md
@@ -5,7 +5,7 @@
 | `rules/defaults.mdc` | Always-on rule: points to `CLAUDE.md` and this tree. |
 | `skills/**/SKILL.md` | e.g. **chrome-devtools-verify**, **drizzle-db-verify**, **commit** |
 | `commands/*.md` | Slash commands: `/ship`, `/ship-light`, `/verify` |
-| `agents/*.md` | **architect**, **critic**, **builder**, **reviewer** |
+| `agents/*.md` | **lead** (branch / PR scope), **architect**, **critic**, **builder**, **reviewer** |
 | `mcp.json` | MCP config (symlinked as `.cursor/mcp.json` after install) |
 
 **Context7 (optional):** The **context7** server in `mcp.json` reads `CONTEXT7_API_KEY` from your environment (set in Cursor MCP env or your shell). Create a key at [context7.com](https://context7.com) (dashboard). Do not commit API keys; keep them in editor-local or OS-level config only.

--- a/.ai-rules/agents/lead.md
+++ b/.ai-rules/agents/lead.md
@@ -1,0 +1,11 @@
+---
+name: lead
+description: Branch hygiene and PR scope when orchestrating /ship (and related flows).
+tools: Read
+model: sonnet
+---
+You are the **Lead** when running **`/ship`** or similar full pipelines. This file documents **branch and PR scope**; the subagents are **`architect`**, **`critic`**, **`builder`**, and **`reviewer`** (see `.ai-rules/agents/*.md`).
+
+**Branch first:** Default **new branch** from synced default: `git fetch && git switch main && git pull` (or `git reset --hard origin/main` if you have nothing local to keep) → `git switch -c <user>/<topic>`. If this branch’s PR is **merged**, never add more work here. If **unmerged**, only stay if this spec is the **same** feature/PR; unrelated work → **new branch**. Doubt → new branch. (`gh pr list --head "$(git branch --show-current)" --state merged` shows merged work.)
+
+**Also:** **`CLAUDE.md`** (# Agents, Definition of done), **`agents/builder.md`** (Phase 3), **commit** skill (push / PR).

--- a/.ai-rules/commands/ship-light.md
+++ b/.ai-rules/commands/ship-light.md
@@ -7,7 +7,7 @@ You are the **Lead** for small, well-scoped work. Faster than full `/ship`; use 
 
 **vs `/ship`:** no plan critic, test critic, or `reviewer` (unless you skim yourself).
 
-**Branch first:** Default **new branch** from synced default: `git fetch && git switch main && git pull` (or `git reset --hard origin/main` if you have nothing local to keep) → `git switch -c <user>/<topic>`. If this branch’s PR is **merged**, never add more work here. If **unmerged**, only stay if this spec is the **same** feature/PR; unrelated work → **new branch**. Doubt → new branch. (`gh pr list --head "$(git branch --show-current)" --state merged` shows merged work.)
+**Branch first:** Same rules as full **`/ship`** — `.ai-rules/agents/lead.md`.
 
 **UI + Chrome MCP:** If the diff touches app UI or routing (see `CLAUDE.md`), run **chrome-devtools-verify** when MCP works; else note “MCP skipped” in **Verification**. Tests + fallow still gate.
 

--- a/.ai-rules/commands/ship.md
+++ b/.ai-rules/commands/ship.md
@@ -3,11 +3,11 @@ description: Run the full plan→test→build→review pipeline
 ---
 Feature spec: $ARGUMENTS
 
-You are the **Lead**. Same **branch** rules as `ship-light`: default **new** branch from updated default; never stack unrelated work on a merged branch; unmerged = same feature only, else new branch. Doubt → new branch.
+You are the **Lead**. **Branch and PR scope:** `.ai-rules/agents/lead.md` (and the other agent briefs under `.ai-rules/agents/` for `architect` → `critic` → `builder` → `reviewer`).
 
 **UI + Chrome MCP:** For UI/routing changes, **chrome-devtools-verify** when MCP works; if not, document in **Verification** — not an automatic `reviewer` **BLOCK** if explained.
 
-0. (Branch — see `ship-light` one-liner above.)
+0. **Branch** — `.ai-rules/agents/lead.md`.
 
 1. `architect` → plan.  
 2. `critic` on plan — BLOCK? refine (max 2 rounds, then escalate).  


### PR DESCRIPTION
## Summary

- Add `.ai-rules/agents/lead.md` with branch/PR scope (single source of truth).
- Update `/ship` to reference `lead.md` and the other agent briefs instead of `ship-light`.
- Point `/ship-light` at `lead.md` for the same branch rules.
- Document **lead** in `.ai-rules/README.md`.

## Test plan

- [x] Read paths in `ship.md` / `ship-light.md` resolve under `.ai-rules/`.

Made with [Cursor](https://cursor.com)