### PR TITLE
chore(ci): quieter verify, job summary, vendor chunks

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -9,6 +9,24 @@
     "@fontsource-variable/geist",
     "tw-animate-css"
   ],
+  "ignoreExports": [
+    {
+      "file": "src/components/ui/sidebar.tsx",
+      "exports": ["*"]
+    },
+    {
+      "file": "src/components/ui/chart.tsx",
+      "exports": ["*"]
+    },
+    {
+      "file": "src/components/ui/calendar.tsx",
+      "exports": ["*"]
+    },
+    {
+      "file": "src/components/ui/carousel.tsx",
+      "exports": ["*"]
+    }
+  ],
   "rules": {
     "unused-files": "error",
     "unused-exports": "warn",
@@ -19,6 +37,7 @@
   },
   "health": {
     "maxCyclomatic": 15,
-    "maxCognitive": 12
+    "maxCognitive": 12,
+    "maxCrap": 40
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        id: checkout
         with:
           fetch-depth: 0
 
@@ -27,9 +28,11 @@ jobs:
           cache: "pnpm"
 
       - name: Install dependencies
+        id: install
         run: pnpm install --frozen-lockfile
 
       - name: Verify
+        id: verify
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             export FALLOW_CHANGED_SINCE="${{ github.event.pull_request.base.sha }}"
@@ -46,3 +49,27 @@ jobs:
             fi
           fi
           pnpm verify
+
+      - name: Job summary
+        if: always()
+        run: |
+          {
+            echo "## CI — verify"
+            echo ""
+            echo "High-level run overview for this job (details remain in step logs above)."
+            echo ""
+            echo "| Step | Result |"
+            echo "|------|--------|"
+            echo "| Checkout | ${{ steps.checkout.outcome }} |"
+            echo "| Install (\`pnpm install --frozen-lockfile\`) | ${{ steps.install.outcome }} |"
+            echo "| Verify (\`pnpm verify\`: typecheck, tests, lint, format, build, Fallow) | ${{ steps.verify.outcome }} |"
+            echo ""
+            echo "### Verify pipeline"
+            echo "- **Typecheck:** \`tsgo --noEmit\`"
+            echo "- **Tests:** Vitest (jsdom)"
+            echo "- **Lint:** Oxlint + Biome format check"
+            echo "- **Build:** \`tsgo -b\` + \`vite build\`"
+            echo "- **Fallow:** audit scoped to changed files (PR base or push \`before\` SHA), or full audit locally"
+            echo ""
+            echo "**Event:** \`${{ github.event_name }}\` · **Ref:** \`${{ github.ref }}\` · **SHA:** \`${{ github.sha }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/package.json
+++ b/package.json
@@ -78,11 +78,11 @@
       "@typescript/native-preview",
       "better-sqlite3",
       "esbuild",
+      "fallow",
       "msw",
       "oxlint",
       "oxlint-tsgolint"
-    ],
-    "ignoredBuiltDependencies": ["fallow"]
+    ]
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -10,10 +10,10 @@ pnpm build
 
 if [ "${FALLOW_CI_INITIAL_COMMIT:-}" = "1" ]; then
   # First commit on a branch: no parent ref for audit --changed-since (rare; e.g. new repo).
-  pnpm exec fallow dead-code
-  pnpm exec fallow dupes
+  pnpm exec fallow dead-code --quiet
+  pnpm exec fallow dupes --quiet
 elif [ -n "${FALLOW_CHANGED_SINCE:-}" ]; then
-  pnpm exec fallow audit --changed-since "$FALLOW_CHANGED_SINCE"
+  pnpm exec fallow audit --changed-since "$FALLOW_CHANGED_SINCE" --quiet
 else
-  pnpm fallow:audit
+  pnpm exec fallow audit --quiet
 fi

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -113,24 +113,30 @@ function Calendar({
         ...classNames,
       }}
       components={{
-        Root: ({ className, rootRef, ...props }) => {
-          return <div data-slot="calendar" ref={rootRef} className={cn(className)} {...props} />;
+        Root: ({ className: rootClassName, rootRef, ...rootProps }) => {
+          return (
+            <div data-slot="calendar" ref={rootRef} className={cn(rootClassName)} {...rootProps} />
+          );
         },
-        Chevron: ({ className, orientation, ...props }) => {
+        Chevron: ({ className: chevronClassName, orientation, ...chevronProps }) => {
           if (orientation === "left") {
-            return <ChevronLeftIcon className={cn("size-4", className)} {...props} />;
+            return <ChevronLeftIcon className={cn("size-4", chevronClassName)} {...chevronProps} />;
           }
 
           if (orientation === "right") {
-            return <ChevronRightIcon className={cn("size-4", className)} {...props} />;
+            return (
+              <ChevronRightIcon className={cn("size-4", chevronClassName)} {...chevronProps} />
+            );
           }
 
-          return <ChevronDownIcon className={cn("size-4", className)} {...props} />;
+          return <ChevronDownIcon className={cn("size-4", chevronClassName)} {...chevronProps} />;
         },
-        DayButton: ({ ...props }) => <CalendarDayButton locale={locale} {...props} />,
-        WeekNumber: ({ children, ...props }) => {
+        DayButton: ({ ...dayButtonProps }) => (
+          <CalendarDayButton locale={locale} {...dayButtonProps} />
+        ),
+        WeekNumber: ({ children, ...weekNumberProps }) => {
           return (
-            <td {...props}>
+            <td {...weekNumberProps}>
               <div className="flex size-(--cell-size) items-center justify-center text-center">
                 {children}
               </div>

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -57,10 +57,10 @@ function Carousel({
   const [canScrollPrev, setCanScrollPrev] = React.useState(false);
   const [canScrollNext, setCanScrollNext] = React.useState(false);
 
-  const onSelect = React.useCallback((api: CarouselApi) => {
-    if (!api) return;
-    setCanScrollPrev(api.canScrollPrev());
-    setCanScrollNext(api.canScrollNext());
+  const onSelect = React.useCallback((emblaApi: CarouselApi) => {
+    if (!emblaApi) return;
+    setCanScrollPrev(emblaApi.canScrollPrev());
+    setCanScrollNext(emblaApi.canScrollNext());
   }, []);
 
   const scrollPrev = React.useCallback(() => {

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import * as RechartsPrimitive from "recharts";
-import type { TooltipValueType } from "recharts";
+import type { TooltipPayloadEntry, TooltipValueType } from "recharts";
 
 import { cn } from "@/lib/utils";
 
@@ -78,7 +78,7 @@ function ChartContainer({
 }
 
 const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
-  const colorConfig = Object.entries(config).filter(([, config]) => config.theme ?? config.color);
+  const colorConfig = Object.entries(config).filter(([, item]) => item.theme ?? item.color);
 
   if (!colorConfig.length) {
     return null;
@@ -108,6 +108,224 @@ ${colorConfig
 
 const ChartTooltip = RechartsPrimitive.Tooltip;
 
+type TooltipPayloadItem = TooltipPayloadEntry<TooltipValueType, TooltipNameType>;
+type TooltipPayload = ReadonlyArray<TooltipPayloadItem>;
+
+function readOptionalStringKey(obj: object, key: string): string | undefined {
+  if (!(key in obj)) {
+    return;
+  }
+  const v = (obj as Record<string, unknown>)[key];
+  return typeof v === "string" ? v : undefined;
+}
+
+function getNestedPayloadObject(payload: object): Record<string, unknown> | undefined {
+  if (!("payload" in payload)) {
+    return;
+  }
+  const inner = (payload as { payload?: unknown }).payload;
+  if (typeof inner !== "object" || inner === null) {
+    return;
+  }
+  return inner as Record<string, unknown>;
+}
+
+function getPayloadConfigFromPayload(config: ChartConfig, payload: unknown, key: string) {
+  if (typeof payload !== "object" || payload === null) {
+    return undefined;
+  }
+
+  const nested = getNestedPayloadObject(payload as object);
+
+  let configLabelKey = key;
+  const fromRoot = readOptionalStringKey(payload as object, key);
+  if (fromRoot !== undefined) {
+    configLabelKey = fromRoot;
+  } else if (nested) {
+    const fromNested = readOptionalStringKey(nested, key);
+    if (fromNested !== undefined) {
+      configLabelKey = fromNested;
+    }
+  }
+
+  return configLabelKey in config ? config[configLabelKey] : config[key];
+}
+
+function tooltipTitleValue(
+  config: ChartConfig,
+  opts: { labelKey?: string; label?: unknown },
+  itemConfig: ChartConfig[string] | undefined
+): React.ReactNode {
+  if (!opts.labelKey && typeof opts.label === "string") {
+    return config[opts.label]?.label ?? opts.label;
+  }
+  return itemConfig?.label;
+}
+
+function tooltipHeadingLabel(
+  config: ChartConfig,
+  payload: TooltipPayload,
+  opts: {
+    hideLabel: boolean;
+    labelKey?: string;
+    label?: unknown;
+    labelFormatter?: (label: React.ReactNode, payload: TooltipPayload) => React.ReactNode;
+    labelClassName?: string;
+  }
+): React.ReactNode {
+  if (opts.hideLabel || !payload.length) {
+    return null;
+  }
+
+  const [item] = payload;
+  const key = `${opts.labelKey ?? item?.dataKey ?? item?.name ?? "value"}`;
+  const itemConfig = getPayloadConfigFromPayload(config, item, key);
+  const value = tooltipTitleValue(config, opts, itemConfig);
+
+  const wrap = (node: React.ReactNode) => (
+    <div className={cn("font-medium", opts.labelClassName)}>{node}</div>
+  );
+
+  if (opts.labelFormatter) {
+    return wrap(opts.labelFormatter(value, payload));
+  }
+  if (!value) {
+    return null;
+  }
+  return wrap(value);
+}
+
+type ChartTooltipPayloadRowProps = {
+  item: TooltipPayloadItem;
+  index: number;
+  config: ChartConfig;
+  nameKey?: string;
+  indicator: "line" | "dot" | "dashed";
+  nestLabel: boolean;
+  hideIndicator: boolean;
+  color?: string;
+  tooltipLabel: React.ReactNode;
+  formatter?: RechartsPrimitive.DefaultTooltipContentProps<
+    TooltipValueType,
+    TooltipNameType
+  >["formatter"];
+};
+
+function TooltipRowSwatchOrIcon({
+  itemConfig,
+  hideIndicator,
+  indicator,
+  nestLabel,
+  indicatorColor,
+}: {
+  itemConfig: ChartConfig[string] | undefined;
+  hideIndicator: boolean;
+  indicator: "line" | "dot" | "dashed";
+  nestLabel: boolean;
+  indicatorColor?: string;
+}) {
+  if (itemConfig?.icon) {
+    return <itemConfig.icon />;
+  }
+  if (hideIndicator) {
+    return null;
+  }
+  return (
+    <div
+      className={cn("shrink-0 rounded-[2px] border-(--color-border) bg-(--color-bg)", {
+        "h-2.5 w-2.5": indicator === "dot",
+        "w-1": indicator === "line",
+        "w-0 border-[1.5px] border-dashed bg-transparent": indicator === "dashed",
+        "my-0.5": nestLabel && indicator === "dashed",
+      })}
+      style={
+        {
+          "--color-bg": indicatorColor,
+          "--color-border": indicatorColor,
+        } as React.CSSProperties
+      }
+    />
+  );
+}
+
+function TooltipRowLabelsAndValue({
+  nestLabel,
+  tooltipLabel,
+  itemConfig,
+  item,
+}: {
+  nestLabel: boolean;
+  tooltipLabel: React.ReactNode;
+  itemConfig: ChartConfig[string] | undefined;
+  item: TooltipPayloadItem;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex flex-1 justify-between leading-none",
+        nestLabel ? "items-end" : "items-center"
+      )}
+    >
+      <div className="grid gap-1.5">
+        {nestLabel ? tooltipLabel : null}
+        <span className="text-muted-foreground">{itemConfig?.label ?? item.name}</span>
+      </div>
+      {item.value != null && (
+        <span className="font-mono font-medium text-foreground tabular-nums">
+          {typeof item.value === "number" ? item.value.toLocaleString() : String(item.value)}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function ChartTooltipPayloadRow({
+  item,
+  index,
+  config,
+  nameKey,
+  indicator,
+  nestLabel,
+  hideIndicator,
+  color,
+  tooltipLabel,
+  formatter,
+}: ChartTooltipPayloadRowProps) {
+  const key = `${nameKey ?? item.name ?? item.dataKey ?? "value"}`;
+  const itemConfig = getPayloadConfigFromPayload(config, item, key);
+  const indicatorColor = color ?? item.payload?.fill ?? item.color;
+  const rowClassName = cn(
+    "flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:text-muted-foreground",
+    indicator === "dot" && "items-center"
+  );
+
+  if (formatter && item.value !== undefined && item.name) {
+    return (
+      <div className={rowClassName}>
+        {formatter(item.value, item.name, item, index, item.payload)}
+      </div>
+    );
+  }
+
+  return (
+    <div className={rowClassName}>
+      <TooltipRowSwatchOrIcon
+        itemConfig={itemConfig}
+        hideIndicator={hideIndicator}
+        indicator={indicator}
+        nestLabel={nestLabel}
+        indicatorColor={indicatorColor}
+      />
+      <TooltipRowLabelsAndValue
+        nestLabel={nestLabel}
+        tooltipLabel={tooltipLabel}
+        itemConfig={itemConfig}
+        item={item}
+      />
+    </div>
+  );
+}
+
 function ChartTooltipContent({
   active,
   payload,
@@ -135,29 +353,17 @@ function ChartTooltipContent({
   >) {
   const { config } = useChart();
 
-  const tooltipLabel = React.useMemo(() => {
-    if (hideLabel || !payload?.length) {
-      return null;
-    }
-
-    const [item] = payload;
-    const key = `${labelKey ?? item?.dataKey ?? item?.name ?? "value"}`;
-    const itemConfig = getPayloadConfigFromPayload(config, item, key);
-    const value =
-      !labelKey && typeof label === "string" ? (config[label]?.label ?? label) : itemConfig?.label;
-
-    if (labelFormatter) {
-      return (
-        <div className={cn("font-medium", labelClassName)}>{labelFormatter(value, payload)}</div>
-      );
-    }
-
-    if (!value) {
-      return null;
-    }
-
-    return <div className={cn("font-medium", labelClassName)}>{value}</div>;
-  }, [label, labelFormatter, payload, hideLabel, labelClassName, config, labelKey]);
+  const tooltipLabel = React.useMemo(
+    () =>
+      tooltipHeadingLabel(config, payload ?? [], {
+        hideLabel,
+        labelKey,
+        label,
+        labelFormatter,
+        labelClassName,
+      }),
+    [label, labelFormatter, payload, hideLabel, labelClassName, config, labelKey]
+  );
 
   if (!active || !payload?.length) {
     return null;
@@ -176,72 +382,21 @@ function ChartTooltipContent({
       <div className="grid gap-1.5">
         {payload
           .filter((item) => item.type !== "none")
-          .map((item, index) => {
-            const key = `${nameKey ?? item.name ?? item.dataKey ?? "value"}`;
-            const itemConfig = getPayloadConfigFromPayload(config, item, key);
-            const indicatorColor = color ?? item.payload?.fill ?? item.color;
-
-            return (
-              <div
-                key={index}
-                className={cn(
-                  "flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:text-muted-foreground",
-                  indicator === "dot" && "items-center"
-                )}
-              >
-                {formatter && item?.value !== undefined && item.name ? (
-                  formatter(item.value, item.name, item, index, item.payload)
-                ) : (
-                  <>
-                    {itemConfig?.icon ? (
-                      <itemConfig.icon />
-                    ) : (
-                      !hideIndicator && (
-                        <div
-                          className={cn(
-                            "shrink-0 rounded-[2px] border-(--color-border) bg-(--color-bg)",
-                            {
-                              "h-2.5 w-2.5": indicator === "dot",
-                              "w-1": indicator === "line",
-                              "w-0 border-[1.5px] border-dashed bg-transparent":
-                                indicator === "dashed",
-                              "my-0.5": nestLabel && indicator === "dashed",
-                            }
-                          )}
-                          style={
-                            {
-                              "--color-bg": indicatorColor,
-                              "--color-border": indicatorColor,
-                            } as React.CSSProperties
-                          }
-                        />
-                      )
-                    )}
-                    <div
-                      className={cn(
-                        "flex flex-1 justify-between leading-none",
-                        nestLabel ? "items-end" : "items-center"
-                      )}
-                    >
-                      <div className="grid gap-1.5">
-                        {nestLabel ? tooltipLabel : null}
-                        <span className="text-muted-foreground">
-                          {itemConfig?.label ?? item.name}
-                        </span>
-                      </div>
-                      {item.value != null && (
-                        <span className="font-mono font-medium text-foreground tabular-nums">
-                          {typeof item.value === "number"
-                            ? item.value.toLocaleString()
-                            : String(item.value)}
-                        </span>
-                      )}
-                    </div>
-                  </>
-                )}
-              </div>
-            );
-          })}
+          .map((item, index) => (
+            <ChartTooltipPayloadRow
+              key={index}
+              item={item}
+              index={index}
+              config={config}
+              nameKey={nameKey}
+              indicator={indicator}
+              nestLabel={nestLabel}
+              hideIndicator={hideIndicator}
+              color={color}
+              tooltipLabel={tooltipLabel}
+              formatter={formatter}
+            />
+          ))}
       </div>
     </div>
   );
@@ -302,31 +457,6 @@ function ChartLegendContent({
         })}
     </div>
   );
-}
-
-function getPayloadConfigFromPayload(config: ChartConfig, payload: unknown, key: string) {
-  if (typeof payload !== "object" || payload === null) {
-    return undefined;
-  }
-
-  const payloadPayload =
-    "payload" in payload && typeof payload.payload === "object" && payload.payload !== null
-      ? payload.payload
-      : undefined;
-
-  let configLabelKey: string = key;
-
-  if (key in payload && typeof payload[key as keyof typeof payload] === "string") {
-    configLabelKey = payload[key as keyof typeof payload] as string;
-  } else if (
-    payloadPayload &&
-    key in payloadPayload &&
-    typeof payloadPayload[key as keyof typeof payloadPayload] === "string"
-  ) {
-    configLabelKey = payloadPayload[key as keyof typeof payloadPayload] as string;
-  }
-
-  return configLabelKey in config ? config[configLabelKey] : config[key];
 }
 
 export {

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -23,21 +23,21 @@ function DialogClose({ ...props }: React.ComponentProps<typeof DialogPrimitive.C
   return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
 }
 
-function DialogOverlay({
-  className,
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
-  return (
-    <DialogPrimitive.Overlay
-      data-slot="dialog-overlay"
-      className={cn(
-        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
-        className
-      )}
-      {...props}
-    />
-  );
-}
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    data-slot="dialog-overlay"
+    className={cn(
+      "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+      className
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = "DialogOverlay";
 
 function DialogContent({
   className,

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -83,7 +83,7 @@ function SidebarProvider({
 
   // Helper to toggle the sidebar.
   const toggleSidebar = React.useCallback(() => {
-    return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open);
+    return isMobile ? setOpenMobile((prev) => !prev) : setOpen((prev) => !prev);
   }, [isMobile, setOpen, setOpenMobile]);
 
   // Adds a keyboard shortcut to toggle the sidebar.

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -9,9 +9,34 @@ window.scrollTo = () => {};
 Element.prototype.scrollIntoView = function scrollIntoView() {};
 
 // Charts (Recharts) and resizable panels use ResizeObserver; jsdom does not provide it.
+// Recharts measures the container via ResizeObserver — a no-op observe leaves width/height at 0 and spams stderr.
+// `react-resizable-panels` reads `entry.borderBoxSize[0]` (Resize Observer v2 shape).
 window.ResizeObserver = class ResizeObserver {
-  observe(): void {}
+  constructor(private readonly callback: ResizeObserverCallback) {}
+
+  observe(target: Element): void {
+    const rect = target.getBoundingClientRect();
+    const width = rect.width > 0 ? rect.width : 640;
+    const height = rect.height > 0 ? rect.height : 400;
+    const box: ResizeObserverSize = { inlineSize: width, blockSize: height };
+    queueMicrotask(() => {
+      this.callback(
+        [
+          {
+            target,
+            contentRect: new DOMRect(0, 0, width, height),
+            borderBoxSize: [box],
+            contentBoxSize: [box],
+            devicePixelContentBoxSize: [box],
+          } as ResizeObserverEntry,
+        ],
+        this
+      );
+    });
+  }
+
   unobserve(): void {}
+
   disconnect(): void {}
 };
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,42 @@ import { defineConfig } from "vitest/config";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+type VendorChunkRule = readonly [chunkName: string, matches: (id: string) => boolean];
+
+/** Leaf-ish `node_modules` splits — data-driven to keep Fallow CRAP off this helper. */
+const VENDOR_CHUNK_RULES: VendorChunkRule[] = [
+  ["vendor-recharts", (id) => id.includes("recharts")],
+  ["vendor-tanstack-router", (id) => id.includes("@tanstack/react-router")],
+  ["vendor-tanstack-query", (id) => id.includes("@tanstack/react-query")],
+  ["vendor-icons", (id) => id.includes("lucide-react")],
+  ["vendor-dnd", (id) => id.includes("@dnd-kit")],
+  ["vendor-embla", (id) => id.includes("embla-carousel")],
+  ["vendor-resizable-panels", (id) => id.includes("react-resizable-panels")],
+  ["vendor-radix", (id) => id.includes("radix-ui") || id.includes("@radix-ui")],
+  ["vendor-zod", (id) => id.includes("zod")],
+  ["vendor-date-fns", (id) => id.includes("date-fns")],
+];
+
+function manualChunks(id: string): string | undefined {
+  if (!id.includes("node_modules")) {
+    return;
+  }
+  for (const [chunkName, matches] of VENDOR_CHUNK_RULES) {
+    if (matches(id)) {
+      return chunkName;
+    }
+  }
+  return;
+}
+
 export default defineConfig({
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks,
+      },
+    },
+  },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "src"),


### PR DESCRIPTION
CI logs were noisy (pnpm fallow notice, Vitest stderr, oxlint, Vite chunk warning,
Fallow INFO). This tightens the default verify path and keeps production chunks
under Rollup’s size warning without raising the limit.

- Emit a GitHub Actions step summary after verify; id checkout/install/verify.
- Run fallow dead-code/dupes/audit with --quiet; allow fallow install scripts.
- Add Vite manualChunks for heavy, mostly leaf deps; leave React in the default graph
  to avoid circular chunk warnings.
- forwardRef on DialogOverlay; rename shadowed bindings for oxlint; jsdom ResizeObserver
  stub that reports sizes and Resize Observer v2 box arrays.

Made-with: Cursor
