### PR TITLE
docs(ai-rules): add project agent skills

### DIFF
--- a/.ai-rules/README.md
+++ b/.ai-rules/README.md
@@ -3,7 +3,7 @@
 | Path | Use |
 |------|-----|
 | `rules/defaults.mdc` | Always-on rule: points to `CLAUDE.md` and this tree. |
-| `skills/**/SKILL.md` | e.g. **chrome-devtools-verify**, **drizzle-db-verify**, **commit** |
+| `skills/**/SKILL.md` | e.g. **project-api**, **tech-debt**, **architecture-adr**, **design-doc**, **strict-tdd**, **systematic-debugging**, **improve-codebase**, **grill-me**, **branch-finishing**, **chrome-devtools-verify**, **drizzle-db-verify**, **commit** |
 | `commands/*.md` | Slash commands: `/ship`, `/ship-light`, `/verify` |
 | `agents/*.md` | **lead** (branch / PR scope), **architect**, **critic**, **builder**, **reviewer** |
 | `mcp.json` | MCP config (symlinked as `.cursor/mcp.json` after install) |

--- a/.ai-rules/skills/architecture-adr/SKILL.md
+++ b/.ai-rules/skills/architecture-adr/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: architecture-adr
+description: Plan and document architecture decisions for significant boundaries, dependencies, storage choices, API contracts, migrations, or cross-system changes. Use when work is large, ambiguous, risky, or needs an ADR-style decision record.
+---
+
+# Architecture / ADR
+
+Use before implementation when a change has meaningful trade-offs or affects multiple ownership boundaries.
+
+## Trigger Examples
+
+- Adding or replacing a dependency, framework, MCP, persistence layer, or API style.
+- Changing API contracts, routing structure, database schema strategy, or state ownership.
+- Refactoring shared modules or behavior used by several pages/services.
+- Introducing feature flags, migrations, background jobs, auth, observability, or deployment behavior.
+
+## Decision Flow
+
+1. **Context** — summarize the problem, current behavior, and constraints from `CLAUDE.md`.
+2. **Forces** — name the trade-offs: type safety, testability, performance, rollout, migration, developer experience, security.
+3. **Options** — compare 2-3 viable approaches, including “keep current pattern” when reasonable.
+4. **Decision** — choose the smallest approach that satisfies the requirement and matches repo conventions.
+5. **Consequences** — call out follow-up work, risks, rollback path, and verification.
+6. **Handoff** — if implementing, identify files, tests, and skills to use next.
+
+## Lightweight ADR Template
+
+```markdown
+# ADR: <decision>
+
+## Context
+
+## Options
+
+## Decision
+
+## Consequences
+
+## Verification
+```
+
+## Repo Defaults
+
+- Prefer the existing stack before adding technology: React, TypeScript strict, Hono, Drizzle, Zod, TanStack Query/Router, Zustand, Vitest, Playwright, Biome, oxlint, Fallow.
+- Query keys come from the `queryKeys` factory.
+- Zod defines API boundaries.
+- UI/routing changes need `chrome-devtools-verify` when MCP works.
+- DB/API/schema changes need `drizzle-db-verify`.

--- a/.ai-rules/skills/branch-finishing/SKILL.md
+++ b/.ai-rules/skills/branch-finishing/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: branch-finishing
+description: Finish a branch for handoff or PR readiness. Use when the user asks to finish, ship, hand off, prepare a PR, make a branch merge-ready, or do a final branch check before review.
+---
+
+# Branch Finishing
+
+This skill is for branch-level readiness. For git safety, commit grouping, push, and PR mechanics, read and follow `commit/SKILL.md`.
+
+## Finish Flow
+
+1. **Scope** — confirm the branch is appropriate for this work. If the branch has a merged PR or unrelated scope, create a fresh branch before adding work.
+2. **Status** — inspect `git status -s`, staged/unstaged diff, untracked files, and recent commits.
+3. **Diff skim** — review the full branch diff against the base branch, not only the latest commit.
+4. **Checks** — run the narrow checks for touched areas, then broader gates when risk warrants:
+   - code/docs only: `pnpm format:check` and Fallow audit as applicable,
+   - shared app code: `pnpm typecheck && pnpm lint && pnpm test && pnpm build`,
+   - DB/API/schema: `drizzle-db-verify`,
+   - UI/routes: `chrome-devtools-verify` when MCP works.
+5. **Fallow** — run Fallow MCP audit or `pnpm fallow audit`; fix `fail`, report `warn`.
+6. **Evidence** — collect verification notes and screenshot paths for UI work. Do not commit verification PNGs unless asked.
+7. **Commit readiness** — use `commit` skill to group changes into buildable commits and avoid unrelated files.
+8. **PR readiness** — push/update the branch and create/update the PR with Summary and Verification sections.
+9. **Clean exit** — end with clean `git status -s` or clearly report remaining intentional changes.
+
+## PR Body Shape
+
+```markdown
+## Summary
+- What changed and why
+
+## Verification
+- Commands run
+- Fallow verdict
+- Live/API/UI evidence when relevant
+```
+
+## Stop Conditions
+
+- Verification still fails after one focused fix round.
+- The branch contains unrelated work that cannot be safely separated.
+- A merged PR already exists for this branch and the user has not approved a new branch.
+- Required credentials or MCPs are unavailable and the missing check is a release blocker.

--- a/.ai-rules/skills/commit/SKILL.md
+++ b/.ai-rules/skills/commit/SKILL.md
@@ -23,7 +23,8 @@ description: Create commits, push, open PR. Git-only.
 3. **Group** into commits (list plan: title, why, files per commit; ask if unclear).
 4. `git add` / `git add -p` → `git commit` with heredoc message.
 5. After all commits: `git log --oneline`, spot-check `git show --name-only` per commit.
-6. **Push:** `git ls-remote --heads origin <branch>` empty → `git push -u origin <branch>`. Else `git fetch origin <branch>` then force-with-lease as needed. **PR:** `gh pr view` or `gh pr create` with `## Summary` + `## Test plan`.
+6. **Push before calling the commit done:** `git ls-remote --heads origin <branch>` empty → `git push -u origin <branch>`. Else `git fetch origin <branch>` then push or force-with-lease as needed. `git status -s` after push.
+7. **PR:** If requested or part of the workflow, `gh pr view` or `gh pr create` with `## Summary` + `## Test plan`.
 
 ## Common
 

--- a/.ai-rules/skills/commit/SKILL.md
+++ b/.ai-rules/skills/commit/SKILL.md
@@ -24,7 +24,7 @@ description: Create commits, push, open PR. Git-only.
 4. `git add` / `git add -p` → `git commit` with heredoc message.
 5. After all commits: `git log --oneline`, spot-check `git show --name-only` per commit.
 6. **Push before calling the commit done:** `git ls-remote --heads origin <branch>` empty → `git push -u origin <branch>`. Else `git fetch origin <branch>` then push or force-with-lease as needed. `git status -s` after push.
-7. **PR:** If requested or part of the workflow, `gh pr view` or `gh pr create` with `## Summary` + `## Test plan`.
+7. **PR before calling the commit done:** `gh pr view` if one exists; otherwise `gh pr create` with `## Summary` + `## Test plan`. Return the PR URL.
 
 ## Common
 

--- a/.ai-rules/skills/design-doc/SKILL.md
+++ b/.ai-rules/skills/design-doc/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: design-doc
+description: Write concise engineering design documents for features, refactors, APIs, migrations, or system changes. Use when the user asks for a design doc, technical proposal, RFC, implementation design, or written plan for review.
+---
+
+# Design Doc
+
+Use for work that needs shared understanding before implementation. For short decision records, use `architecture-adr`; for implementation after approval, use the relevant build skill.
+
+## Process
+
+1. Clarify the goal, non-goals, constraints, and success criteria.
+2. Read the current code paths before proposing changes.
+3. Identify affected modules, contracts, data flow, and verification gates.
+4. Compare meaningful options when trade-offs exist.
+5. Recommend one approach and explain why it fits this repo.
+6. Include rollout, risks, test plan, and open questions.
+
+## Template
+
+```markdown
+# Design: <title>
+
+## Summary
+
+## Goals
+
+## Non-Goals
+
+## Current State
+
+## Proposed Design
+
+## Alternatives Considered
+
+## Data / API Contracts
+
+## Testing and Verification
+
+## Rollout and Risks
+
+## Open Questions
+```
+
+## Repo Guidance
+
+- Cite specific files and existing patterns.
+- Prefer existing stack choices from `CLAUDE.md` unless the design justifies a new tool.
+- Include Zod schemas for API boundaries when relevant.
+- Include TanStack Query key/invalidation behavior for server data.
+- Include Drizzle migration and live-smoke requirements for DB/API changes.
+- Include Chrome DevTools verification for UI/routes when MCP works.
+
+## Keep It Reviewable
+
+- Keep the main document concise; link references instead of dumping large code.
+- Mark assumptions clearly.
+- Separate “decision needed” from “implementation detail”.
+- Do not hide unresolved trade-offs.

--- a/.ai-rules/skills/grill-me/SKILL.md
+++ b/.ai-rules/skills/grill-me/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: grill-me
+description: Challenge proposed feature additions or feature changes with direct questions, trade-off pressure, and sharper alternatives. Use when the user asks to be grilled on an idea, pressure-test a feature, or think through product/engineering implications before planning.
+---
+
+# Grill Me
+
+Use this skill when the user has a feature idea and wants to be challenged before committing to a plan. Be direct, specific, and constructive.
+
+## Challenge Areas
+
+- **User value** — who needs this, what pain it removes, and how success is measured.
+- **Scope** — smallest useful version, non-goals, and what should be deferred.
+- **Product fit** — whether the idea matches the app's purpose and current UX.
+- **Technical shape** — affected routes, API contracts, data model, state ownership, and verification.
+- **Risks** — edge cases, failure modes, migrations, accessibility, security, and maintenance cost.
+- **Alternatives** — simpler workflows, reuse of existing surfaces, or no-build options.
+
+## Flow
+
+1. Restate the proposed feature or change in one sentence.
+2. Ask 3-5 hard questions before suggesting implementation.
+3. Name the strongest argument for the idea and the strongest argument against it.
+4. Identify the smallest version worth building.
+5. Call out assumptions that need evidence.
+6. Recommend one of: proceed, narrow scope, run a spike, write a design doc, or do not build yet.
+
+## Style
+
+- Do not rubber-stamp ideas. Be useful.
+- Push on assumptions, edge cases, and operational concerns.
+- If the proposal is vague, ask for specifics: user, workflow, data shape, API contract, failure mode, test, or metric.
+- Prefer narrowing to an MVP over expanding scope.
+- Tie feedback to this repo when helpful: Hono, Drizzle, Zod, TanStack Query, Biome/oxlint, Vitest, Playwright, Fallow, MCPs, and `.ai-rules`.
+
+## Output
+
+```markdown
+## Pressure Test
+- Best case:
+- Main risk:
+- Smallest useful version:
+- Questions to answer:
+
+## Recommendation
+Proceed / narrow / spike / design doc / do not build yet
+```

--- a/.ai-rules/skills/improve-codebase/SKILL.md
+++ b/.ai-rules/skills/improve-codebase/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: improve-codebase
+description: Identify and implement scoped codebase improvements using repo conventions, Fallow signals, tests, and small reviewable batches. Use when users ask to improve, modernize, clean up, harden, simplify, or make the codebase more maintainable.
+---
+
+# Improve Codebase
+
+Use this skill for broad improvement requests. Start by narrowing scope and finding evidence; do not begin with a large refactor.
+
+## Improvement Areas
+
+- Correctness: bugs, missing edge cases, unsafe assumptions.
+- Maintainability: duplicated logic, unclear boundaries, oversized modules.
+- Type safety: weak schemas, avoidable casts, missing invariants.
+- UX quality: loading/error/empty states, accessibility, route behavior.
+- API quality: validation, status codes, error shape, query invalidation.
+- Code health: dead code, complexity, dependency drift, circular imports.
+- Verification: missing tests, weak smoke checks, unclear PR evidence.
+
+## Workflow
+
+1. Clarify the target: whole repo, directory, feature, or pain point.
+2. Gather evidence: tests, Fallow MCP/CLI, lints, recent diffs, bug reports, and code reads.
+3. Propose 2-4 small batches ranked by impact and risk.
+4. For each batch, state files, expected behavior, and verification.
+5. Implement one batch at a time unless the user asks for a plan only.
+6. Use `strict-tdd` for behavior changes and `systematic-debugging` for known failures.
+7. Use `tech-debt` before broad cleanup or deletion.
+8. Use `architecture-adr` or `design-doc` when the improvement changes boundaries or introduces a new pattern.
+9. Finish with `branch-finishing` when the branch is ready for handoff.
+
+## Guardrails
+
+- Keep shipped behavior compatible unless the user explicitly wants a breaking change.
+- Prefer existing patterns over new abstractions.
+- Do not mix unrelated refactors with feature or bug-fix commits.
+- Do not add dependencies until the gap is clear and documented.
+- Avoid churn in generated files, lockfiles, or formatting outside the target scope.
+
+## Report Shape
+
+```markdown
+## Findings
+- Evidence-backed opportunity
+
+## Proposed Batches
+1. Change, files, risk, verification
+
+## Completed
+- What changed
+
+## Verification
+- Commands and results
+```

--- a/.ai-rules/skills/project-api/SKILL.md
+++ b/.ai-rules/skills/project-api/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: project-api
+description: Scaffold or change this repo's API flow across Hono, Zod, Drizzle, and TanStack Query. Use when adding endpoints, request/response schemas, database-backed server behavior, API clients, query keys, or mutation hooks.
+---
+
+# Project API
+
+Use for API work that crosses `server/`, `db/`, `drizzle/`, or `src/api/`.
+
+## Shape
+
+| Concern | Location |
+|---------|----------|
+| Hono routes | `server/index.ts` |
+| Server helpers | `server/*.ts` |
+| Shared schemas | `src/api/*.schemas.ts` |
+| Client functions + hooks | `src/api/*.ts` |
+| Tables | `db/schema.ts` |
+| Migrations | `drizzle/` via `pnpm db:generate` |
+| Tests | colocated `*.test.tsx` / API tests under `src/api/` |
+
+## Scaffold Order
+
+1. **Contract first** — define Zod request/response schemas in `src/api/<resource>.schemas.ts`; export `z.infer` types.
+2. **Server** — add small Hono route wiring in `server/index.ts`; move validation, persistence, and error mapping into `server/<resource>*.ts` helpers when logic grows.
+3. **Database** — if schema changes, update `db/schema.ts`, run `pnpm db:generate`, and commit generated `drizzle/` files.
+4. **Client** — add fetch functions in `src/api/<resource>.ts`; parse responses with Zod and parse outgoing bodies before `fetch`.
+5. **Query keys** — extend the existing `queryKeys` factory; never use inline keys in components.
+6. **Hooks** — use TanStack Query for server data. Mutations should invalidate by `queryKeys`, not ad-hoc refetch.
+7. **UI** — components/pages consume hooks and typed schemas; keep Zustand for client UI/session state only.
+8. **Tests** — cover happy, validation error, server error, empty/null, and mutation invalidation where relevant.
+9. **Verify** — use `drizzle-db-verify` for `db/`, `server/`, `drizzle/`, or shared server schema changes.
+
+## Conventions
+
+- Zod is the API boundary; do not trust raw JSON on either side.
+- Prefer narrow server helpers over expanding `server/index.ts`.
+- Return clear JSON errors from API handlers; keep status-code behavior covered by tests.
+- Avoid `any`, `@ts-ignore`, stray logs, and inline query keys.
+- Use Context7 when Hono, Drizzle, Zod, or TanStack behavior depends on current upstream docs.

--- a/.ai-rules/skills/strict-tdd/SKILL.md
+++ b/.ai-rules/skills/strict-tdd/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: strict-tdd
+description: Enforce red-green-refactor for behavior changes. Use when adding features, fixing bugs, changing API behavior, or when the user asks for TDD, tests first, regression coverage, or strict test discipline.
+---
+
+# Strict TDD
+
+Use for meaningful behavior changes. Docs-only, pure formatting, generated migrations, and mechanical renames may skip TDD with a short note.
+
+## Red-Green-Refactor
+
+1. **Red** — write the smallest failing test that describes the desired behavior or regression.
+2. Run the targeted test and observe the expected failure. If the test unexpectedly passes, tighten the assertion before coding.
+3. **Green** — implement the smallest change that makes the test pass.
+4. Run the targeted test until green.
+5. **Refactor** — clean up names, structure, and duplication without changing behavior.
+6. Run the targeted test again, then broaden verification based on risk.
+
+## Test Targets
+
+- API contracts: schema parsing, status codes, error bodies, empty states.
+- TanStack Query hooks: query keys, mutation invalidation, loading/error states.
+- UI: user-visible behavior with React Testing Library; add Chrome DevTools verification for changed UI/routes when MCP works.
+- DB/server: include `drizzle-db-verify` when touching `db/`, `server/`, `drizzle/`, or shared server schemas.
+
+## Discipline
+
+- Do not batch several unverified fixes together.
+- Prefer one behavior per test.
+- Keep tests user-facing where possible; avoid testing implementation details.
+- If a failing test cannot be created first, explain why and add regression coverage immediately after reproducing the issue another way.
+- Never remove or weaken tests only to make a change pass.
+
+## Finish
+
+Report:
+
+- the failing test observed,
+- the implementation path,
+- final targeted test command,
+- broader verification command if run.

--- a/.ai-rules/skills/systematic-debugging/SKILL.md
+++ b/.ai-rules/skills/systematic-debugging/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: systematic-debugging
+description: Diagnose and fix bugs through reproduction, evidence, isolation, root cause, regression tests, and verification. Use when behavior is broken, tests fail, CI fails, runtime errors appear, or the user asks to debug.
+---
+
+# Systematic Debugging
+
+Use this when something is failing or surprising. Move from evidence to cause before editing.
+
+## Workflow
+
+1. **Reproduce** — identify the exact failing command, UI flow, API request, or CI check.
+2. **Capture evidence** — read the error, stack, failing assertion, console/network output, or relevant logs.
+3. **Narrow scope** — locate the smallest component, function, route, schema, or query involved.
+4. **State a hypothesis** — one likely cause and one quick way to prove or disprove it.
+5. **Test the hypothesis** — use a targeted test, small script, focused command, or code read.
+6. **Fix root cause** — make one coherent change; avoid speculative multi-fix batches.
+7. **Add regression coverage** — test the bug or invariant that should have caught it.
+8. **Verify** — run the smallest relevant check first, then the broader gate needed for the touched area.
+
+## Useful Checks
+
+- Unit/API: `pnpm test <file>` or `pnpm test`.
+- Types: `pnpm typecheck`.
+- Lint/format: `pnpm lint`, `pnpm format:check`.
+- DB/API live smoke: `drizzle-db-verify`.
+- UI/browser: `chrome-devtools-verify`.
+- Code health after edits: Fallow MCP or `pnpm fallow audit`.
+
+## Reporting
+
+Summarize:
+
+- Reproduction.
+- Root cause.
+- Fix.
+- Regression test.
+- Verification.
+
+## Avoid
+
+- Editing before reproducing unless the failure is already explicit and local.
+- Treating symptoms while leaving the invariant untested.
+- Hiding errors with broad catches, fallback defaults, or disabled checks.

--- a/.ai-rules/skills/tech-debt/SKILL.md
+++ b/.ai-rules/skills/tech-debt/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: tech-debt
+description: Assess and plan technical debt cleanup using Fallow audit, health, dead-code, and duplication signals. Use when users mention tech debt, cleanup, dead code, complexity, duplication, refactoring priority, or code health.
+---
+
+# Tech Debt
+
+Use this skill to turn cleanup into a prioritized plan before deleting or refactoring broadly.
+
+## Evidence First
+
+Prefer Fallow MCP tools when available:
+
+- `audit` for changed-file dead code, complexity, and duplication.
+- `check_health` for complexity hotspots.
+- `find_dupes` for clone groups.
+- `analyze` or `check_changed` when a broader read is needed.
+
+CLI fallbacks:
+
+- `pnpm fallow audit`
+- `pnpm fallow health`
+- `pnpm fallow dead-code`
+- `pnpm fallow dead-code --production` before deleting code
+
+## Workflow
+
+1. Define the cleanup scope: branch diff, directory, feature area, or production-only code.
+2. Gather Fallow results and recent git/test context; do not rely on hunches alone.
+3. Classify items by impact: correctness risk, maintenance cost, user-facing blast radius, and ease of verification.
+4. Recommend small batches. Each batch should be independently reviewable and testable.
+5. Before deletion, confirm production reachability with Fallow and local usage search.
+6. Preserve public interfaces, persisted data, migrations, and shipped behavior unless the user explicitly wants a breaking cleanup.
+7. Verify with targeted tests, then `pnpm fallow audit`; run broader `pnpm verify` for shared or risky changes.
+
+## Output
+
+Use this format for cleanup plans:
+
+```markdown
+## Findings
+- [severity] path/symbol: reason and evidence
+
+## Recommended Batches
+1. Scope, expected change, verification
+
+## Risks
+- Compatibility, data, or UI concerns
+```
+
+## Avoid
+
+- Large opportunistic refactors.
+- Deleting code only because it looks unused.
+- Suppressing Fallow findings without a reason.
+- Mixing mechanical cleanup with behavior changes in one commit.


### PR DESCRIPTION
## Summary
- Add repo-specific agent skills for API scaffolding, tech debt, architecture decisions, design docs, TDD, debugging, branch finishing, feature pressure-testing, and scoped codebase improvement.
- Update the commit skill so a commit workflow pushes before considering the work done.
- Document the expanded skill set in `.ai-rules/README.md`.

## Test plan
- `pnpm format:check`
- `ReadLints` on changed skill docs: no issues
- Fallow MCP audit: pass with 0 code files analyzed for markdown-only changes
- Pre-commit `pnpm run fallow:audit`: pass

Made with [Cursor](https://cursor.com)