### PR TITLE
docs(ai-rules): rename route skill

### DIFF
--- a/.ai-rules/skills/tanstack-routes/SKILL.md
+++ b/.ai-rules/skills/tanstack-routes/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: tanstack-routes
-description: Add/change TanStack Router routes; keep `AppShell` nav in sync.
+name: route
+description: /route — Add/change TanStack Router routes; keep `AppShell` nav in sync.
 ---
 
-# Routes + shell
+# /route
 
 | Task | File |
 |------|------|


### PR DESCRIPTION
## Summary
- Rename the TanStack routes skill metadata to `route`.
- Update the skill description and heading to present it as `/route` while preserving the existing route guidance.

## Test plan
- `pnpm format:check`
- `ReadLints` on `.ai-rules/skills/tanstack-routes/SKILL.md`: no issues

Made with [Cursor](https://cursor.com)