### PR TITLE
chore(ci): use Node 24 in verify workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "pnpm"
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- Update CI's `actions/setup-node` configuration from Node 20 to Node 24.
- Align the verify workflow with GitHub Actions' Node 24 runtime to remove the Node 20 deprecation annotation.

## Test plan
- Commit hook ran `pnpm run fallow:audit` successfully.
- Not run: full `pnpm verify` because this is a CI YAML-only warning fix.

Made with [Cursor](https://cursor.com)