### PR TITLE
Add DB-backed local login

### DIFF
--- a/db/schema.ts
+++ b/db/schema.ts
@@ -7,4 +7,11 @@ export const users = sqliteTable("users", {
   role: text("role", { enum: ["admin", "member"] }).notNull(),
 });
 
+export const authSession = sqliteTable("auth_session", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  email: text("email").notNull(),
+});
+
 export type UserRow = typeof users.$inferSelect;
+export type AuthSessionRow = typeof authSession.$inferSelect;

--- a/drizzle/0001_tearful_pride.sql
+++ b/drizzle/0001_tearful_pride.sql
@@ -1,0 +1,5 @@
+CREATE TABLE `auth_session` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`email` text NOT NULL
+);

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,93 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "fe8295ab-201c-4194-bcae-c7b475d28529",
+  "prevId": "fce0fba2-7048-47bc-92ca-f54b8a73c114",
+  "tables": {
+    "auth_session": {
+      "name": "auth_session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1776909207827,
       "tag": "0000_faithful_lilith",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1777178870635,
+      "tag": "0001_tearful_pride",
+      "breakpoints": true
     }
   ]
 }

--- a/server/authSession.ts
+++ b/server/authSession.ts
@@ -1,0 +1,43 @@
+import { eq } from "drizzle-orm";
+import type { Context } from "hono";
+import type { Db } from "../db/client";
+import { authSession } from "../db/schema";
+import { LoginBodySchema } from "../src/api/auth.schemas";
+import { readJsonOrBadRequest } from "./requestJson";
+
+const AUTH_SESSION_ID = "current";
+
+export function handleGetAuthSession(c: Context, db: Db) {
+  const row = db.select().from(authSession).where(eq(authSession.id, AUTH_SESSION_ID)).get();
+  if (!row) return c.json(null);
+  return c.json({ name: row.name, email: row.email });
+}
+
+export async function handlePostAuthSession(c: Context, db: Db) {
+  const read = await readJsonOrBadRequest(c);
+  if (!read.ok) return read.response;
+
+  const parsed = LoginBodySchema.safeParse(read.body);
+  if (!parsed.success) {
+    return c.json(
+      { error: "Validation failed", fieldErrors: parsed.error.flatten().fieldErrors },
+      400
+    );
+  }
+
+  const row = { id: AUTH_SESSION_ID, ...parsed.data };
+  db.insert(authSession)
+    .values(row)
+    .onConflictDoUpdate({
+      target: authSession.id,
+      set: { name: row.name, email: row.email },
+    })
+    .run();
+
+  return c.json({ name: row.name, email: row.email });
+}
+
+export function handleDeleteAuthSession(db: Db) {
+  db.delete(authSession).where(eq(authSession.id, AUTH_SESSION_ID)).run();
+  return new Response(null, { status: 204 });
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -7,6 +7,11 @@ import { Hono } from "hono";
 import { createDb } from "../db/client";
 import { users } from "../db/schema";
 import { seedUsers } from "../db/seed-data";
+import {
+  handleDeleteAuthSession,
+  handleGetAuthSession,
+  handlePostAuthSession,
+} from "./authSession";
 import { getShipVerifyResponse } from "./shipVerify";
 import { existingUserForIdParam } from "./userLookup";
 import { handlePatchUser, handlePostUser } from "./userMutations";
@@ -31,6 +36,12 @@ app.get("/api/ship-verify", (c) => {
     return c.json({ error: "Ship verify failed" }, 500);
   }
 });
+
+app.get("/api/auth", (c) => handleGetAuthSession(c, db));
+
+app.post("/api/auth", (c) => handlePostAuthSession(c, db));
+
+app.delete("/api/auth", () => handleDeleteAuthSession(db));
 
 app.get("/api/users", (c) => {
   const rows = db.select().from(users).all();

--- a/src/api/auth.schemas.ts
+++ b/src/api/auth.schemas.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+export const AuthSessionSchema = z.object({
+  name: z.string().trim().min(1, "Name is required").max(80, "Name must be 80 characters or fewer"),
+  email: z.string().trim().email("Enter a valid email").max(254, "Email is too long"),
+});
+
+export const AuthSessionResponseSchema = AuthSessionSchema.nullable();
+export const LoginBodySchema = AuthSessionSchema;
+
+export type AuthSession = z.infer<typeof AuthSessionSchema>;
+export type LoginBody = z.infer<typeof LoginBodySchema>;

--- a/src/api/auth.test.tsx
+++ b/src/api/auth.test.tsx
@@ -1,0 +1,195 @@
+import { type QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import type { ReactNode } from "react";
+import { describe, expect, it } from "vitest";
+import { ZodError } from "zod";
+import { server } from "../mocks/server";
+import { createTestQueryClient } from "../test/utils";
+import {
+  fetchAuthSession,
+  login,
+  logout,
+  queryKeys,
+  useAuthSession,
+  useLogin,
+  useLogout,
+} from "./auth";
+
+function wrapper(queryClient: QueryClient) {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe("queryKeys.auth.current", () => {
+  it("returns the readonly tuple ['auth', 'current']", () => {
+    expect(queryKeys.auth.current()).toEqual(["auth", "current"]);
+  });
+});
+
+describe("fetchAuthSession", () => {
+  it("returns null when no auth session is stored", async () => {
+    expect(await fetchAuthSession()).toBeNull();
+  });
+
+  it("returns a parsed auth session when one is stored", async () => {
+    await login({ name: "Ada Lovelace", email: "ada@example.com" });
+
+    await expect(fetchAuthSession()).resolves.toEqual({
+      name: "Ada Lovelace",
+      email: "ada@example.com",
+    });
+  });
+
+  it("throws on a non-ok response", async () => {
+    server.use(http.get("/api/auth", () => new HttpResponse(null, { status: 500 })));
+
+    await expect(fetchAuthSession()).rejects.toThrow(/HTTP 500/);
+  });
+
+  it("throws a ZodError when the server returns malformed data", async () => {
+    server.use(http.get("/api/auth", () => HttpResponse.json({ name: "Missing email" })));
+
+    await expect(fetchAuthSession()).rejects.toBeInstanceOf(ZodError);
+  });
+});
+
+describe("login", () => {
+  it("stores and returns the submitted name and email", async () => {
+    await expect(login({ name: "Grace Hopper", email: "grace@example.com" })).resolves.toEqual({
+      name: "Grace Hopper",
+      email: "grace@example.com",
+    });
+  });
+
+  it("rejects an empty name before sending the request", async () => {
+    await expect(login({ name: "", email: "valid@example.com" })).rejects.toBeInstanceOf(ZodError);
+  });
+
+  it("rejects whitespace-only names before sending the request", async () => {
+    await expect(login({ name: "   ", email: "valid@example.com" })).rejects.toBeInstanceOf(
+      ZodError
+    );
+  });
+
+  it("rejects an invalid email before sending the request", async () => {
+    await expect(login({ name: "Valid", email: "not-an-email" })).rejects.toBeInstanceOf(ZodError);
+  });
+
+  it("rejects an empty email before sending the request", async () => {
+    await expect(login({ name: "Valid", email: "" })).rejects.toBeInstanceOf(ZodError);
+  });
+
+  it("throws on a non-ok response", async () => {
+    server.use(http.post("/api/auth", () => new HttpResponse(null, { status: 500 })));
+
+    await expect(login({ name: "Server Error", email: "server@example.com" })).rejects.toThrow(
+      /HTTP 500/
+    );
+  });
+
+  it("throws a ZodError when the server returns a malformed success body", async () => {
+    server.use(http.post("/api/auth", () => HttpResponse.json({ email: "broken@example.com" })));
+
+    await expect(login({ name: "Broken", email: "broken@example.com" })).rejects.toBeInstanceOf(
+      ZodError
+    );
+  });
+});
+
+describe("logout", () => {
+  it("succeeds even when no auth session exists", async () => {
+    await expect(logout()).resolves.toBeUndefined();
+  });
+
+  it("throws on a non-ok response", async () => {
+    server.use(http.delete("/api/auth", () => new HttpResponse(null, { status: 500 })));
+
+    await expect(logout()).rejects.toThrow(/HTTP 500/);
+  });
+
+  it("clears a stored auth session", async () => {
+    await login({ name: "Linus Torvalds", email: "linus@example.com" });
+    await logout();
+
+    await expect(fetchAuthSession()).resolves.toBeNull();
+  });
+});
+
+describe("useAuthSession", () => {
+  it("starts in a loading state and resolves with null", async () => {
+    const queryClient = createTestQueryClient();
+    const { result } = renderHook(() => useAuthSession(), { wrapper: wrapper(queryClient) });
+
+    expect(result.current.isPending).toBe(true);
+    expect(result.current.data).toBeUndefined();
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toBeNull();
+  });
+
+  it("enters an error state when the server returns a 500", async () => {
+    server.use(http.get("/api/auth", () => new HttpResponse(null, { status: 500 })));
+    const queryClient = createTestQueryClient();
+    const { result } = renderHook(() => useAuthSession(), { wrapper: wrapper(queryClient) });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error).toBeInstanceOf(Error);
+  });
+
+  it("enters an error state when the server returns malformed data", async () => {
+    server.use(http.get("/api/auth", () => HttpResponse.json({ name: "Missing email" })));
+    const queryClient = createTestQueryClient();
+    const { result } = renderHook(() => useAuthSession(), { wrapper: wrapper(queryClient) });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error).toBeInstanceOf(ZodError);
+  });
+});
+
+describe("auth mutations", () => {
+  it("refetches the current auth session after login", async () => {
+    const queryClient = createTestQueryClient();
+    await queryClient.prefetchQuery({
+      queryKey: queryKeys.auth.current(),
+      queryFn: fetchAuthSession,
+    });
+    const { result } = renderHook(() => useLogin(), { wrapper: wrapper(queryClient) });
+
+    await result.current.mutateAsync({ name: "Katherine Johnson", email: "kj@example.com" });
+
+    const session = await queryClient.fetchQuery({
+      queryKey: queryKeys.auth.current(),
+      queryFn: fetchAuthSession,
+    });
+    expect(session).toEqual({ name: "Katherine Johnson", email: "kj@example.com" });
+  });
+
+  it("refetches the current auth session after logout", async () => {
+    const queryClient = createTestQueryClient();
+    await login({ name: "Alan Turing", email: "alan@example.com" });
+    await queryClient.prefetchQuery({
+      queryKey: queryKeys.auth.current(),
+      queryFn: fetchAuthSession,
+    });
+    const { result } = renderHook(() => useLogout(), { wrapper: wrapper(queryClient) });
+
+    await result.current.mutateAsync();
+
+    const session = await queryClient.fetchQuery({
+      queryKey: queryKeys.auth.current(),
+      queryFn: fetchAuthSession,
+    });
+    expect(session).toBeNull();
+  });
+});

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,0 +1,81 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  type AuthSession,
+  AuthSessionResponseSchema,
+  AuthSessionSchema,
+  type LoginBody,
+  LoginBodySchema,
+} from "./auth.schemas";
+import { queryKeys } from "./queryKeys";
+
+export type { AuthSession, LoginBody } from "./auth.schemas";
+export { AuthSessionSchema, LoginBodySchema, queryKeys };
+
+function messageFromErrorResponse(res: Response, errText: string): string {
+  let message = errText || `HTTP ${res.status}`;
+  try {
+    const parsed = JSON.parse(errText) as { error?: string };
+    if (parsed.error) message = parsed.error;
+  } catch {
+    // Keep the HTTP fallback when the server does not return JSON.
+  }
+  return message;
+}
+
+export async function fetchAuthSession(): Promise<AuthSession | null> {
+  const res = await fetch("/api/auth");
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return AuthSessionResponseSchema.parse(await res.json());
+}
+
+export async function login(body: LoginBody): Promise<AuthSession> {
+  const parsed = LoginBodySchema.parse(body);
+  const res = await fetch("/api/auth", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(parsed),
+  });
+  if (!res.ok) {
+    const errText = await res.text();
+    throw new Error(messageFromErrorResponse(res, errText));
+  }
+  return AuthSessionSchema.parse(await res.json());
+}
+
+export async function logout(): Promise<void> {
+  const res = await fetch("/api/auth", { method: "DELETE" });
+  if (res.status === 204) return;
+  if (!res.ok) {
+    const errText = await res.text();
+    throw new Error(messageFromErrorResponse(res, errText));
+  }
+}
+
+export function useAuthSession() {
+  return useQuery({
+    queryKey: queryKeys.auth.current(),
+    queryFn: fetchAuthSession,
+    retry: 0,
+    staleTime: 30_000,
+  });
+}
+
+export function useLogin() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: login,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: queryKeys.auth.current() });
+    },
+  });
+}
+
+export function useLogout() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: logout,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: queryKeys.auth.current() });
+    },
+  });
+}

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -8,8 +8,7 @@ import {
 } from "./auth.schemas";
 import { queryKeys } from "./queryKeys";
 
-export type { AuthSession, LoginBody } from "./auth.schemas";
-export { AuthSessionSchema, LoginBodySchema, queryKeys };
+export { queryKeys };
 
 function messageFromErrorResponse(res: Response, errText: string): string {
   let message = errText || `HTTP ${res.status}`;

--- a/src/api/queryKeys.ts
+++ b/src/api/queryKeys.ts
@@ -1,0 +1,14 @@
+export const queryKeys = {
+  auth: {
+    current: () => ["auth", "current"] as const,
+  },
+  users: {
+    all: () => ["users"] as const,
+  },
+  shipVerify: {
+    all: () => ["ship-verify"] as const,
+  },
+  shipReport: {
+    diff: (path: string) => ["ship-report", "diff", path] as const,
+  },
+} as const;

--- a/src/api/shipVerify.ts
+++ b/src/api/shipVerify.ts
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
+import { queryKeys } from "./queryKeys";
 import { type ShipVerifyResponse, ShipVerifyResponseSchema } from "./shipVerify.schemas";
-import { queryKeys } from "./users";
 
 export async function fetchShipVerify(): Promise<ShipVerifyResponse> {
   const res = await fetch("/api/ship-verify");

--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { queryKeys } from "./queryKeys";
 import {
   type CreateUserBody,
   CreateUserBodySchema,
@@ -13,15 +14,7 @@ export type { CreateUserBody, UpdateUserBody, User } from "./users.schemas";
 
 // fallow-ignore-next-line unused-export
 export { CreateUserBodySchema, UpdateUserBodySchema, UserSchema } from "./users.schemas";
-
-export const queryKeys = {
-  users: {
-    all: () => ["users"] as const,
-  },
-  shipVerify: {
-    all: () => ["ship-verify"] as const,
-  },
-} as const;
+export { queryKeys } from "./queryKeys";
 
 function messageFromErrorResponse(res: Response, errText: string): string {
   let message = errText || `HTTP ${res.status}`;

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -1,3 +1,4 @@
+import { useAuthSession, useLogout } from "@/api/auth";
 import { Button } from "@/components/ui/button";
 import {
   Sidebar,
@@ -21,6 +22,7 @@ import {
   Info,
   LayoutDashboard,
   LayoutGrid,
+  LogIn,
   Moon,
   PanelsTopLeft,
   Sun,
@@ -31,12 +33,53 @@ import * as React from "react";
 const mainNav: { to: string; label: string; icon: React.ComponentType<{ className?: string }> }[] =
   [
     { to: "/users", label: "Users", icon: Users },
+    { to: "/login", label: "Login", icon: LogIn },
     { to: "/playground", label: "Playground", icon: LayoutGrid },
     { to: "/components-demo", label: "Components", icon: PanelsTopLeft },
     { to: "/dashboard-demo", label: "Dashboard", icon: LayoutDashboard },
     { to: "/ship-report", label: "Ship report", icon: ClipboardList },
     { to: "/about", label: "About", icon: Info },
   ];
+
+function AuthControls() {
+  const { data: session, isPending, isError } = useAuthSession();
+  const logoutMutation = useLogout();
+
+  if (isPending) {
+    return <span className="text-xs text-muted-foreground">Loading auth...</span>;
+  }
+
+  if (isError) {
+    return <span className="text-xs text-destructive">Sign-in unavailable</span>;
+  }
+
+  if (!session) {
+    return (
+      <Button asChild variant="outline" size="sm">
+        <Link to="/login">Sign in</Link>
+      </Button>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <span className="hidden text-sm text-muted-foreground sm:inline">
+        Current user: {session.name}
+      </span>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={() => {
+          void logoutMutation.mutateAsync();
+        }}
+        disabled={logoutMutation.isPending}
+      >
+        {logoutMutation.isPending ? "Signing out..." : "Sign out"}
+      </Button>
+    </div>
+  );
+}
 
 export function AppShell({ children }: { children: React.ReactNode }) {
   const pathname = useRouterState({ select: (s) => s.location.pathname });
@@ -84,6 +127,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
         >
           <SidebarTrigger className="md:-ml-1" />
           <div className="ml-auto flex items-center gap-2">
+            <AuthControls />
             <Button
               type="button"
               variant="outline"

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -4,6 +4,7 @@ import type { ShipVerifyResponse } from "../api/shipVerify.schemas";
 import type { User } from "../api/users.schemas";
 
 let userList: User[] = seedUsers.map((u) => ({ ...u }));
+let authSession: { name: string; email: string } | null = null;
 
 export const userFixtures = seedUsers;
 
@@ -11,7 +12,12 @@ function resetList() {
   userList = seedUsers.map((u) => ({ ...u }));
 }
 
+function resetAuth() {
+  authSession = null;
+}
+
 export { resetList as resetUserHandlersState };
+export { resetAuth as resetAuthHandlersState };
 
 function parseMockUserBody(body: { name?: string; email?: string; role?: string }):
   | { ok: true; name: string; email: string; role: "admin" | "member" }
@@ -43,6 +49,25 @@ export const handlers = [
       },
     };
     return HttpResponse.json(body);
+  }),
+
+  http.get("/api/auth", () => HttpResponse.json(authSession)),
+
+  http.post("/api/auth", async ({ request }) => {
+    const body = (await request.json()) as { name?: string; email?: string };
+    if (!body.name?.trim() || !body.email?.includes("@")) {
+      return HttpResponse.json(
+        { error: "Validation failed", fieldErrors: { name: ["Name is required"] } },
+        { status: 400 }
+      );
+    }
+    authSession = { name: body.name.trim(), email: body.email };
+    return HttpResponse.json(authSession);
+  }),
+
+  http.delete("/api/auth", () => {
+    authSession = null;
+    return new HttpResponse(null, { status: 204 });
   }),
 
   http.get("/api/users", () => HttpResponse.json(userList)),

--- a/src/pages/LoginPage.test.tsx
+++ b/src/pages/LoginPage.test.tsx
@@ -1,0 +1,142 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it } from "vitest";
+import { server } from "../mocks/server";
+import { useUiStore } from "../store/uiStore";
+import { renderWithRouter } from "../test/utils";
+
+describe("LoginPage", () => {
+  beforeEach(() => {
+    useUiStore.setState({ darkMode: false });
+  });
+
+  it("renders the logged-out form at /login", async () => {
+    renderWithRouter({ initialPath: "/login" });
+
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /sign in/i })).toBeInTheDocument()
+    );
+    expect(screen.getByLabelText(/^name/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^email/i)).toBeInTheDocument();
+  });
+
+  it("shows loading and error states for the current session request", async () => {
+    server.use(
+      http.get("/api/auth", async () => {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        return new HttpResponse(null, { status: 500 });
+      })
+    );
+
+    renderWithRouter({ initialPath: "/login" });
+
+    expect(await screen.findByText(/checking sign-in status/i)).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(/could not load sign-in status/i)
+    );
+  });
+
+  it("shows validation errors for an empty name and invalid email", async () => {
+    const user = userEvent.setup();
+    renderWithRouter({ initialPath: "/login" });
+
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /sign in/i })).toBeInTheDocument()
+    );
+    await user.type(screen.getByLabelText(/^email/i), "not-an-email");
+    await user.click(screen.getByRole("button", { name: /^sign in$/i }));
+
+    expect(await screen.findByText(/name is required/i)).toBeInTheDocument();
+    expect(screen.getByText(/enter a valid email/i)).toBeInTheDocument();
+  });
+
+  it("submits with the Enter key and trims whitespace-only names as invalid", async () => {
+    const user = userEvent.setup();
+    renderWithRouter({ initialPath: "/login" });
+
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /sign in/i })).toBeInTheDocument()
+    );
+    await user.type(screen.getByLabelText(/^name/i), "   ");
+    await user.type(screen.getByLabelText(/^email/i), "space@example.com{Enter}");
+
+    expect(await screen.findByText(/name is required/i)).toBeInTheDocument();
+  });
+
+  it("disables the submit button while login is pending", async () => {
+    const user = userEvent.setup();
+    let session: { name: string; email: string } | null = null;
+    server.use(
+      http.get("/api/auth", () => HttpResponse.json(session)),
+      http.post("/api/auth", async () => {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        session = { name: "Slow Login", email: "slow@example.com" };
+        return HttpResponse.json(session);
+      })
+    );
+    renderWithRouter({ initialPath: "/login" });
+
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /sign in/i })).toBeInTheDocument()
+    );
+    await user.type(screen.getByLabelText(/^name/i), "Slow Login");
+    await user.type(screen.getByLabelText(/^email/i), "slow@example.com");
+    await user.click(screen.getByRole("button", { name: /^sign in$/i }));
+
+    expect(screen.getByRole("button", { name: /signing in/i })).toBeDisabled();
+    expect(await screen.findByRole("heading", { name: /signed in/i })).toBeInTheDocument();
+  });
+
+  it("shows an alert when login fails", async () => {
+    const user = userEvent.setup();
+    server.use(http.post("/api/auth", () => new HttpResponse(null, { status: 500 })));
+    renderWithRouter({ initialPath: "/login" });
+
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /sign in/i })).toBeInTheDocument()
+    );
+    await user.type(screen.getByLabelText(/^name/i), "Server Error");
+    await user.type(screen.getByLabelText(/^email/i), "server@example.com");
+    await user.click(screen.getByRole("button", { name: /^sign in$/i }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/could not sign in/i);
+  });
+
+  it("stores login details and focuses the signed-in summary", async () => {
+    const user = userEvent.setup();
+    renderWithRouter({ initialPath: "/login" });
+
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /sign in/i })).toBeInTheDocument()
+    );
+    await user.type(screen.getByLabelText(/^name/i), "Margaret Hamilton");
+    await user.type(screen.getByLabelText(/^email/i), "margaret@example.com");
+    await user.click(screen.getByRole("button", { name: /^sign in$/i }));
+
+    const summary = await screen.findByRole("heading", { name: /signed in/i });
+    expect(summary).toHaveFocus();
+    expect(screen.getByText("Margaret Hamilton")).toBeInTheDocument();
+    expect(screen.getByText("margaret@example.com")).toBeInTheDocument();
+    expect(screen.getByText(/signed in as margaret hamilton/i)).toBeInTheDocument();
+  });
+
+  it("logs out and returns focus to the name field", async () => {
+    const user = userEvent.setup();
+    renderWithRouter({ initialPath: "/login" });
+
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /sign in/i })).toBeInTheDocument()
+    );
+    await user.type(screen.getByLabelText(/^name/i), "Barbara Liskov");
+    await user.type(screen.getByLabelText(/^email/i), "barbara@example.com");
+    await user.click(screen.getByRole("button", { name: /^sign in$/i }));
+    await screen.findByRole("heading", { name: /signed in/i });
+
+    await user.click(screen.getByRole("button", { name: /^log out$/i }));
+
+    const nameField = await screen.findByLabelText(/^name/i);
+    expect(nameField).toHaveFocus();
+    expect(screen.queryByText("Barbara Liskov")).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,0 +1,184 @@
+import { useAuthSession, useLogin, useLogout } from "@/api/auth";
+import { LoginBodySchema } from "@/api/auth.schemas";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { type FormEvent, useEffect, useRef, useState } from "react";
+
+type FieldErrors = Partial<Record<"name" | "email", string>>;
+
+function firstFieldErrors(errors: ReturnType<typeof LoginBodySchema.safeParse>): FieldErrors {
+  if (errors.success) return {};
+  const flattened = errors.error.flatten().fieldErrors;
+  return {
+    name: flattened.name?.[0],
+    email: flattened.email?.[0],
+  };
+}
+
+export function LoginPage() {
+  const { data: session, isPending: isSessionPending, isError: isSessionError } = useAuthSession();
+  const loginMutation = useLogin();
+  const logoutMutation = useLogout();
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+  const [focusSummaryAfterLogin, setFocusSummaryAfterLogin] = useState(false);
+  const [focusNameAfterLogout, setFocusNameAfterLogout] = useState(false);
+  const summaryRef = useRef<HTMLHeadingElement>(null);
+  const nameRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (session && focusSummaryAfterLogin) {
+      summaryRef.current?.focus();
+      setFocusSummaryAfterLogin(false);
+    }
+  }, [focusSummaryAfterLogin, session]);
+
+  useEffect(() => {
+    if (!session && focusNameAfterLogout && !isSessionPending) {
+      nameRef.current?.focus();
+      setFocusNameAfterLogout(false);
+    }
+  }, [focusNameAfterLogout, isSessionPending, session]);
+
+  async function onSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    loginMutation.reset();
+    const parsed = LoginBodySchema.safeParse({ name, email });
+    if (!parsed.success) {
+      setFieldErrors(firstFieldErrors(parsed));
+      return;
+    }
+
+    setFieldErrors({});
+    try {
+      await loginMutation.mutateAsync(parsed.data);
+      setFocusSummaryAfterLogin(true);
+    } catch {
+      // TanStack Query stores the error for rendering below.
+    }
+  }
+
+  async function onLogout() {
+    try {
+      await logoutMutation.mutateAsync();
+      setName("");
+      setEmail("");
+      setFocusNameAfterLogout(true);
+    } catch {
+      // The mutation state owns logout error handling.
+    }
+  }
+
+  if (isSessionPending) {
+    return <p className="text-sm text-muted-foreground">Checking sign-in status...</p>;
+  }
+
+  if (isSessionError) {
+    return (
+      <div role="alert" className="rounded-md border border-destructive/40 p-4 text-destructive">
+        Could not load sign-in status.
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-lg space-y-6">
+      {session ? (
+        <section className="rounded-lg border bg-card p-6 text-card-foreground shadow-sm">
+          <h1 ref={summaryRef} tabIndex={-1} className="text-2xl font-semibold tracking-tight">
+            Signed in
+          </h1>
+          <p className="mt-2 text-sm text-muted-foreground">Signed in as {session.name}</p>
+          <dl className="mt-4 space-y-2 text-sm">
+            <div>
+              <dt className="font-medium">Name</dt>
+              <dd>{session.name}</dd>
+            </div>
+            <div>
+              <dt className="font-medium">Email</dt>
+              <dd>{session.email}</dd>
+            </div>
+          </dl>
+          <Button
+            type="button"
+            variant="outline"
+            className="mt-6"
+            onClick={() => {
+              void onLogout();
+            }}
+            disabled={logoutMutation.isPending}
+          >
+            {logoutMutation.isPending ? "Logging out..." : "Log out"}
+          </Button>
+        </section>
+      ) : (
+        <form
+          noValidate
+          aria-label="Sign in"
+          className="rounded-lg border bg-card p-6 text-card-foreground shadow-sm"
+          onSubmit={(event) => {
+            void onSubmit(event);
+          }}
+        >
+          <h1 className="text-2xl font-semibold tracking-tight">Sign in</h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Store your name and email in the local SQLite database.
+          </p>
+          <div className="mt-6 space-y-4">
+            <div>
+              <label htmlFor="login-name" className="text-sm font-medium">
+                Name
+              </label>
+              <Input
+                ref={nameRef}
+                id="login-name"
+                name="name"
+                autoComplete="name"
+                value={name}
+                aria-invalid={fieldErrors.name ? true : undefined}
+                aria-describedby={fieldErrors.name ? "login-name-error" : undefined}
+                onChange={(event) => setName(event.target.value)}
+              />
+              {fieldErrors.name ? (
+                <p id="login-name-error" className="mt-1 text-sm text-destructive">
+                  {fieldErrors.name}
+                </p>
+              ) : null}
+            </div>
+            <div>
+              <label htmlFor="login-email" className="text-sm font-medium">
+                Email
+              </label>
+              <Input
+                id="login-email"
+                name="email"
+                type="text"
+                inputMode="email"
+                autoComplete="email"
+                value={email}
+                aria-invalid={fieldErrors.email ? true : undefined}
+                aria-describedby={fieldErrors.email ? "login-email-error" : undefined}
+                onChange={(event) => setEmail(event.target.value)}
+              />
+              {fieldErrors.email ? (
+                <p id="login-email-error" className="mt-1 text-sm text-destructive">
+                  {fieldErrors.email}
+                </p>
+              ) : null}
+            </div>
+          </div>
+          {loginMutation.isError ? (
+            <p role="alert" className="mt-4 text-sm text-destructive">
+              Could not sign in:{" "}
+              {loginMutation.error instanceof Error ? loginMutation.error.message : "Unknown error"}
+            </p>
+          ) : null}
+          <Button type="submit" className="mt-6" disabled={loginMutation.isPending}>
+            {loginMutation.isPending ? "Signing in..." : "Sign in"}
+          </Button>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,8 +1,16 @@
 import { useAuthSession, useLogin, useLogout } from "@/api/auth";
-import { LoginBodySchema } from "@/api/auth.schemas";
+import { type AuthSession, LoginBodySchema } from "@/api/auth.schemas";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { type FormEvent, useEffect, useRef, useState } from "react";
+import {
+  type Dispatch,
+  type FormEvent,
+  type RefObject,
+  type SetStateAction,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 
 type FieldErrors = Partial<Record<"name" | "email", string>>;
 
@@ -13,6 +21,145 @@ function firstFieldErrors(errors: ReturnType<typeof LoginBodySchema.safeParse>):
     name: flattened.name?.[0],
     email: flattened.email?.[0],
   };
+}
+
+function SessionLoading() {
+  return <p className="text-sm text-muted-foreground">Checking sign-in status...</p>;
+}
+
+function SessionError() {
+  return (
+    <div role="alert" className="rounded-md border border-destructive/40 p-4 text-destructive">
+      Could not load sign-in status.
+    </div>
+  );
+}
+
+function SignedInSummary({
+  session,
+  summaryRef,
+  isLogoutPending,
+  onLogout,
+}: {
+  session: AuthSession;
+  summaryRef: RefObject<HTMLHeadingElement>;
+  isLogoutPending: boolean;
+  onLogout: () => void;
+}) {
+  return (
+    <section className="rounded-lg border bg-card p-6 text-card-foreground shadow-sm">
+      <h1 ref={summaryRef} tabIndex={-1} className="text-2xl font-semibold tracking-tight">
+        Signed in
+      </h1>
+      <p className="mt-2 text-sm text-muted-foreground">Signed in as {session.name}</p>
+      <dl className="mt-4 space-y-2 text-sm">
+        <div>
+          <dt className="font-medium">Name</dt>
+          <dd>{session.name}</dd>
+        </div>
+        <div>
+          <dt className="font-medium">Email</dt>
+          <dd>{session.email}</dd>
+        </div>
+      </dl>
+      <Button
+        type="button"
+        variant="outline"
+        className="mt-6"
+        onClick={onLogout}
+        disabled={isLogoutPending}
+      >
+        {isLogoutPending ? "Logging out..." : "Log out"}
+      </Button>
+    </section>
+  );
+}
+
+function LoginForm({
+  name,
+  email,
+  fieldErrors,
+  isLoginPending,
+  loginError,
+  nameRef,
+  onEmailChange,
+  onNameChange,
+  onSubmit,
+}: {
+  name: string;
+  email: string;
+  fieldErrors: FieldErrors;
+  isLoginPending: boolean;
+  loginError: Error | null;
+  nameRef: RefObject<HTMLInputElement>;
+  onEmailChange: Dispatch<SetStateAction<string>>;
+  onNameChange: Dispatch<SetStateAction<string>>;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+}) {
+  return (
+    <form
+      noValidate
+      aria-label="Sign in"
+      className="rounded-lg border bg-card p-6 text-card-foreground shadow-sm"
+      onSubmit={onSubmit}
+    >
+      <h1 className="text-2xl font-semibold tracking-tight">Sign in</h1>
+      <p className="mt-2 text-sm text-muted-foreground">
+        Store your name and email in the local SQLite database.
+      </p>
+      <div className="mt-6 space-y-4">
+        <div>
+          <label htmlFor="login-name" className="text-sm font-medium">
+            Name
+          </label>
+          <Input
+            ref={nameRef}
+            id="login-name"
+            name="name"
+            autoComplete="name"
+            value={name}
+            aria-invalid={fieldErrors.name ? true : undefined}
+            aria-describedby={fieldErrors.name ? "login-name-error" : undefined}
+            onChange={(event) => onNameChange(event.target.value)}
+          />
+          {fieldErrors.name ? (
+            <p id="login-name-error" className="mt-1 text-sm text-destructive">
+              {fieldErrors.name}
+            </p>
+          ) : null}
+        </div>
+        <div>
+          <label htmlFor="login-email" className="text-sm font-medium">
+            Email
+          </label>
+          <Input
+            id="login-email"
+            name="email"
+            type="text"
+            inputMode="email"
+            autoComplete="email"
+            value={email}
+            aria-invalid={fieldErrors.email ? true : undefined}
+            aria-describedby={fieldErrors.email ? "login-email-error" : undefined}
+            onChange={(event) => onEmailChange(event.target.value)}
+          />
+          {fieldErrors.email ? (
+            <p id="login-email-error" className="mt-1 text-sm text-destructive">
+              {fieldErrors.email}
+            </p>
+          ) : null}
+        </div>
+      </div>
+      {loginError ? (
+        <p role="alert" className="mt-4 text-sm text-destructive">
+          Could not sign in: {loginError.message}
+        </p>
+      ) : null}
+      <Button type="submit" className="mt-6" disabled={isLoginPending}>
+        {isLoginPending ? "Signing in..." : "Sign in"}
+      </Button>
+    </form>
+  );
 }
 
 export function LoginPage() {
@@ -70,114 +217,34 @@ export function LoginPage() {
     }
   }
 
-  if (isSessionPending) {
-    return <p className="text-sm text-muted-foreground">Checking sign-in status...</p>;
-  }
-
-  if (isSessionError) {
-    return (
-      <div role="alert" className="rounded-md border border-destructive/40 p-4 text-destructive">
-        Could not load sign-in status.
-      </div>
-    );
-  }
+  if (isSessionPending) return <SessionLoading />;
+  if (isSessionError) return <SessionError />;
 
   return (
     <div className="mx-auto w-full max-w-lg space-y-6">
       {session ? (
-        <section className="rounded-lg border bg-card p-6 text-card-foreground shadow-sm">
-          <h1 ref={summaryRef} tabIndex={-1} className="text-2xl font-semibold tracking-tight">
-            Signed in
-          </h1>
-          <p className="mt-2 text-sm text-muted-foreground">Signed in as {session.name}</p>
-          <dl className="mt-4 space-y-2 text-sm">
-            <div>
-              <dt className="font-medium">Name</dt>
-              <dd>{session.name}</dd>
-            </div>
-            <div>
-              <dt className="font-medium">Email</dt>
-              <dd>{session.email}</dd>
-            </div>
-          </dl>
-          <Button
-            type="button"
-            variant="outline"
-            className="mt-6"
-            onClick={() => {
-              void onLogout();
-            }}
-            disabled={logoutMutation.isPending}
-          >
-            {logoutMutation.isPending ? "Logging out..." : "Log out"}
-          </Button>
-        </section>
+        <SignedInSummary
+          session={session}
+          summaryRef={summaryRef}
+          isLogoutPending={logoutMutation.isPending}
+          onLogout={() => {
+            void onLogout();
+          }}
+        />
       ) : (
-        <form
-          noValidate
-          aria-label="Sign in"
-          className="rounded-lg border bg-card p-6 text-card-foreground shadow-sm"
+        <LoginForm
+          name={name}
+          email={email}
+          fieldErrors={fieldErrors}
+          isLoginPending={loginMutation.isPending}
+          loginError={loginMutation.error instanceof Error ? loginMutation.error : null}
+          nameRef={nameRef}
+          onNameChange={setName}
+          onEmailChange={setEmail}
           onSubmit={(event) => {
             void onSubmit(event);
           }}
-        >
-          <h1 className="text-2xl font-semibold tracking-tight">Sign in</h1>
-          <p className="mt-2 text-sm text-muted-foreground">
-            Store your name and email in the local SQLite database.
-          </p>
-          <div className="mt-6 space-y-4">
-            <div>
-              <label htmlFor="login-name" className="text-sm font-medium">
-                Name
-              </label>
-              <Input
-                ref={nameRef}
-                id="login-name"
-                name="name"
-                autoComplete="name"
-                value={name}
-                aria-invalid={fieldErrors.name ? true : undefined}
-                aria-describedby={fieldErrors.name ? "login-name-error" : undefined}
-                onChange={(event) => setName(event.target.value)}
-              />
-              {fieldErrors.name ? (
-                <p id="login-name-error" className="mt-1 text-sm text-destructive">
-                  {fieldErrors.name}
-                </p>
-              ) : null}
-            </div>
-            <div>
-              <label htmlFor="login-email" className="text-sm font-medium">
-                Email
-              </label>
-              <Input
-                id="login-email"
-                name="email"
-                type="text"
-                inputMode="email"
-                autoComplete="email"
-                value={email}
-                aria-invalid={fieldErrors.email ? true : undefined}
-                aria-describedby={fieldErrors.email ? "login-email-error" : undefined}
-                onChange={(event) => setEmail(event.target.value)}
-              />
-              {fieldErrors.email ? (
-                <p id="login-email-error" className="mt-1 text-sm text-destructive">
-                  {fieldErrors.email}
-                </p>
-              ) : null}
-            </div>
-          </div>
-          {loginMutation.isError ? (
-            <p role="alert" className="mt-4 text-sm text-destructive">
-              Could not sign in:{" "}
-              {loginMutation.error instanceof Error ? loginMutation.error.message : "Unknown error"}
-            </p>
-          ) : null}
-          <Button type="submit" className="mt-6" disabled={loginMutation.isPending}>
-            {loginMutation.isPending ? "Signing in..." : "Sign in"}
-          </Button>
-        </form>
+        />
       )}
     </div>
   );

--- a/src/router.test.tsx
+++ b/src/router.test.tsx
@@ -33,6 +33,14 @@ describe("router", () => {
     );
   });
 
+  it("renders LoginPage at /login", async () => {
+    renderWithRouter({ initialPath: "/login" });
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: /sign in/i })).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: /login/i })).toHaveAttribute("aria-current", "page");
+    });
+  });
+
   it("renders ComponentsDemoPage at /components-demo", async () => {
     renderWithRouter({ initialPath: "/components-demo" });
     await waitFor(() =>

--- a/src/router.ts
+++ b/src/router.ts
@@ -9,6 +9,7 @@ import { App } from "./App";
 import { AboutPage } from "./pages/AboutPage";
 import { ComponentsDemoPage } from "./pages/ComponentsDemoPage";
 import { DashboardDemoPage } from "./pages/DashboardDemoPage";
+import { LoginPage } from "./pages/LoginPage";
 import { PlaygroundPage } from "./pages/PlaygroundPage";
 import { ShipReportPage } from "./pages/ShipReportPage";
 import { UsersPage } from "./pages/UsersPage";
@@ -35,6 +36,12 @@ const playgroundRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/playground",
   component: PlaygroundPage,
+});
+
+const loginRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/login",
+  component: LoginPage,
 });
 
 const aboutRoute = createRoute({
@@ -64,6 +71,7 @@ const shipReportRoute = createRoute({
 const routeTree = rootRoute.addChildren([
   indexRoute,
   usersRoute,
+  loginRoute,
   playgroundRoute,
   componentsDemoRoute,
   dashboardDemoRoute,

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom/vitest";
 import { afterAll, afterEach, beforeAll } from "vitest";
-import { resetUserHandlersState } from "../mocks/handlers";
+import { resetAuthHandlersState, resetUserHandlersState } from "../mocks/handlers";
 import { server } from "../mocks/server";
 
 // jsdom does not implement window.scrollTo — stub it to suppress "not implemented" noise
@@ -76,6 +76,7 @@ Object.defineProperty(window, "matchMedia", {
 
 beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
 afterEach(() => {
+  resetAuthHandlersState();
   resetUserHandlersState();
   server.resetHandlers();
 });


### PR DESCRIPTION
## Summary
- Add a DB-backed local login session stored in SQLite via `GET/POST/DELETE /api/auth`.
- Add `/login` with typed Zod validation, loading/error/pending states, focus management, and AppShell auth controls.
- Add Drizzle migration, TanStack Query hooks, MSW handlers, and tests for API, hooks, UI, and routing.

## Test plan
- `pnpm vitest run src/api/auth.test.tsx src/pages/LoginPage.test.tsx src/router.test.tsx`
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm verify`
- `pnpm fallow audit --format json` -> `warn` (duplication warnings only; no dead-code or complexity findings)
- Live API smoke: `GET /api/auth` -> 200 null; `POST /api/auth` -> 200 `{ name, email }`; follow-up GET -> 200 stored session; `DELETE /api/auth` -> 204; `GET /api/ship-verify` -> 200 with `drizzleMigrationsCount: 2`.
- Chrome DevTools: `/login` sign-in/logout flow and `/ship-report`; no console warnings/errors; fetches 200.

## Verification Evidence
- `verification/login-name-email/login-signed-in.png`
- `verification/login-name-email/login-logged-out.png`
- `verification/login-name-email/ship-report.png`

## Breaking
- None.

## Follow-ups
- Consider extracting shared API test/fetch helpers if the duplication warnings become noisy across more resources.

Made with [Cursor](https://cursor.com)