### PR TITLE
chore(hooks): single-source precommit for Husky

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,2 @@
 bash scripts/precommit-merged-pr-guard.sh
-pnpm exec lint-staged --no-stash
-pnpm run fallow:audit:precommit
+pnpm run precommit

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "prepare": "husky",
     "postinstall": "node scripts/ensure-ai-rules-symlinks.mjs",
     "ai-rules:link": "node scripts/ensure-ai-rules-symlinks.mjs",
-    "precommit": "lint-staged && pnpm run fallow:audit"
+    "precommit": "pnpm exec lint-staged --no-stash && pnpm run fallow:audit:precommit"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx,mts,cts,json,jsonc,css}": "biome check --write",


### PR DESCRIPTION
## Summary

- Husky `pre-commit` now delegates to `pnpm run precommit` after the merged-PR guard, so lint-staged and Fallow precommit are defined in one place.
- The `precommit` npm script matches what the hook ran: `lint-staged --no-stash` and `fallow:audit:precommit`. It previously ran full `fallow audit`, which duplicated/overlapped the dedicated precommit script and disagreed with the hook.

## Note

This repo has **no** `post-commit` hook; redundancy was between the hook and the `precommit` package script. Full `fallow audit` remains on **`pnpm verify`** (`scripts/verify.sh`) for CI/local verify.

## Test plan

- `pnpm verify` (green in worktree).

## Coverage

- N/A (hook/package.json only; client Vitest thresholds unchanged).

Made with [Cursor](https://cursor.com)