### PR TITLE
docs: README architecture; babysit ai-rules

### DIFF
--- a/.ai-rules/README.md
+++ b/.ai-rules/README.md
@@ -3,7 +3,8 @@
 | Path | Use |
 |------|-----|
 | `rules/defaults.mdc` | Always-on rule: points to `CLAUDE.md` and this tree. |
-| `skills/**/SKILL.md` | e.g. **project-api**, **tech-debt**, **architecture-adr**, **design-doc**, **strict-tdd**, **systematic-debugging**, **improve-codebase**, **grill-me**, **branch-finishing**, **chrome-devtools-verify**, **drizzle-db-verify**, **commit** |
+| `rules/babysit.mdc` | When relevant: PR merge-ready loop (CI, conflicts, comment triage). Not always-on. |
+| `skills/**/SKILL.md` | e.g. **project-api**, **tech-debt**, **babysit**, **fix-comments**, **architecture-adr**, **design-doc**, **strict-tdd**, **systematic-debugging**, **improve-codebase**, **grill-me**, **branch-finishing**, **chrome-devtools-verify**, **drizzle-db-verify**, **commit** |
 | `commands/*.md` | Slash commands: `/ship`, `/ship-light`, `/verify` |
 | `agents/*.md` | **lead** (branch / PR scope), **architect**, **critic**, **builder**, **reviewer** |
 | `mcp.json` | MCP config (symlinked as `.cursor/mcp.json` after install) |

--- a/.ai-rules/rules/babysit.mdc
+++ b/.ai-rules/rules/babysit.mdc
@@ -1,0 +1,16 @@
+---
+description: >-
+  PR babysit / merge-ready loop — CI (e.g. pnpm verify), merge conflicts, comment
+  triage including bots. For threaded review replies + id selection, prefer fix-comments skill.
+alwaysApply: false
+---
+
+When the user wants to **babysit** a PR or keep a branch **merge-ready**:
+
+- Use **`gh`** (and GitHub MCP if available) for PR state and CI.
+- **CI:** align fixes with root **`CLAUDE.md`**; run **`pnpm verify`** locally when debugging failures.
+- **Conflicts:** sync with base; resolve only when the right resolution is clear—otherwise ask.
+- **Comments:** address actionable feedback; skip or dispute low-value items with a short note. For GitHub **review threads**, structured replies, and “which comments to implement,” use **`.ai-rules/skills/fix-comments/SKILL.md`**.
+- **Git / push:** follow **commit** skill; watch force-push policy on shared branches.
+
+Full workflow: **`.ai-rules/skills/babysit/SKILL.md`**.

--- a/.ai-rules/skills/babysit/SKILL.md
+++ b/.ai-rules/skills/babysit/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: babysit
+description: >-
+  Keep a PR merge-ready: triage comments, resolve clear merge conflicts, fix CI
+  in a loop until green and mergeable.
+---
+
+# Babysit PR
+
+Get the current PR to a **merge-ready** state: CI matches **`CLAUDE.md` / `pnpm verify`**, conflicts resolved when intent is clear, and review feedback handled deliberately.
+
+## Relationship to other skills
+
+- **`fix-comments`** — Structured pass on **unresolved GitHub review threads** (pick IDs → implement → threaded replies). Use when the main work is **responding to human review** on an open PR.
+- **`babysit`** — Broader **ops loop**: CI failures, base-branch sync / conflicts, Bugbot or noisy bots, and “keep pushing until green.” Overlaps with fix-comments when CI fails because of code review items; use **fix-comments** for reply etiquette and thread resolution when that is the primary task.
+
+## Loop
+
+1. **Status** — `gh pr view`, CI checks, mergeable state, draft vs ready.
+2. **Comments** — Read threads (including Bugbot). Implement fixes you agree with; push back briefly when you disagree or need product input—do not blindly apply everything.
+3. **Merge conflicts** — Rebase or merge from base; resolve only when **intent is obvious**. If the correct resolution is ambiguous, stop and ask.
+4. **CI** — Reproduce locally when possible (`pnpm verify` for this repo). Small, scoped commits; push and re-check CI until green.
+5. **Stop** — When checks pass, branch is up to date, and open feedback is addressed or explicitly deferred.
+
+**Need:** `gh auth login`; GitHub MCP optional. Follow **commit** skill for push / force-with-lease policy on shared branches.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,129 @@ React + Vite + TanStack Query + Zod + Hono + SQLite, with a shared **`.ai-rules/
 4. **Run the app** — API + Vite: `pnpm dev` (or `pnpm dev:ready` to wait for ports, then `pnpm dev:stop` when done). Default UI: [http://localhost:5173](http://localhost:5173); API: [http://127.0.0.1:8787](http://127.0.0.1:8787).
 5. **Optional** — [GitHub CLI](https://cli.github.com) (`gh auth login` for PRs), Chrome DevTools MCP and Context7 in Cursor (see `.ai-rules/mcp.json` and **`.ai-rules/README.md`** for `CONTEXT7_API_KEY`), and any secrets in local-only files (e.g. **`.claude/settings.local.json`**, not committed).
 
+## Architecture
+
+This repo is a **single-package** TypeScript monolith: a **Vite SPA** talks to a **Node HTTP API** backed by **SQLite** via **Drizzle ORM**. API shapes are validated with **Zod** and shared between client and server where it keeps boundaries honest.
+
+### Runtime topology
+
+In development, two processes run: **Vite** (UI + dev middleware) and **tsx** (API). The browser calls `/api/*`; Vite **proxies** those requests to the API so the UI keeps same-origin `fetch("/api/...")` URLs.
+
+```mermaid
+flowchart LR
+  subgraph browser["Browser"]
+    UI["React app"]
+  end
+
+  subgraph dev["Development"]
+    Vite["Vite :5173"]
+    API["Hono + tsx :8787"]
+    DB["SQLite data/local.sqlite"]
+  end
+
+  UI -->|"/*"| Vite
+  UI -->|"/api/*"| Vite
+  Vite -->|proxy /api| API
+  API --> DB
+```
+
+With the default **dev** setup, **MSW** handles most `/api/*` in the browser (see **Client application** below), so traffic often never reaches the proxy or `:8787` until you disable mocks or call the API directly (for example `curl` to `http://127.0.0.1:8787`). **Production** builds do not start MSW; `fetch("/api/...")` goes to wherever the app is hosted, typically via the same reverse proxy as the API.
+
+Production usage is typically **build the static client** (`pnpm build`) and **serve the API** (same Hono app) with the `dist/` assets hosted separately or behind a reverse proxy—not automated in this repo’s dev scripts.
+
+When the browser issues `fetch("/api/...")` and the call is **not** intercepted by MSW, Vite proxies it to the API process:
+
+```mermaid
+sequenceDiagram
+  participant B as Browser
+  participant V as Vite dev server
+  participant A as Hono on 8787
+  participant D as SQLite
+
+  B->>V: GET /api/users
+  V->>A: forward /api
+  A->>D: query via Drizzle
+  D-->>A: rows
+  A-->>V: 200 JSON
+  V-->>B: 200 JSON
+```
+
+### Client application
+
+The UI is a **TanStack Router** tree under `src/router.ts`, with a root layout (`App` → `AppShell` → `<Outlet />`). **TanStack Query** owns server-backed data; **Zustand** is reserved for purely client UI state (for example theme in `src/store/uiStore.ts`), matching the “never both for the same data” rule in `CLAUDE.md`.
+
+```mermaid
+flowchart TB
+  subgraph client["src/"]
+    Router["TanStack Router"]
+    Pages["pages/*"]
+    Components["components/**"]
+    ApiHooks["api/* — hooks + fetch + queryKeys"]
+    Schemas["api/*.schemas.ts — Zod"]
+    UiStore["store/uiStore — Zustand"]
+  end
+
+  Router --> Pages
+  Pages --> Components
+  Pages --> ApiHooks
+  ApiHooks --> Schemas
+  Components --> UiStore
+```
+
+In **development**, **MSW** (`src/mocks/`) intercepts `/api/*` in the browser so the UI can run against deterministic fixtures; **production builds** do not start the mock worker (`src/main.tsx`).
+
+### Server and data layer
+
+The API lives in **`server/`**: a **Hono** app created in `server/index.ts`. On startup it runs **Drizzle migrations** from `drizzle/`, **seeds** an empty database from `db/seed-data.ts`, and exposes REST-style JSON endpoints (`GET/POST/PATCH/DELETE` for users, plus `GET /api/ship-verify` for health-style DB checks).
+
+**`db/`** holds the **SQLite schema** (`db/schema.ts`), **`createDb`** (`db/client.ts` → `data/local.sqlite`, WAL mode), and seeds. **Drizzle Kit** drives `db:generate`, `db:migrate`, `db:push`, etc. (`drizzle.config.ts`).
+
+```mermaid
+flowchart LR
+  subgraph server["server/"]
+    Hono["Hono routes"]
+    Mutations["userMutations, userLookup"]
+    Ship["shipVerify + shipDbStats"]
+  end
+
+  subgraph data["db/ + data/"]
+    Drizzle["Drizzle ORM"]
+    SQLite[("SQLite file")]
+  end
+
+  Hono --> Mutations
+  Hono --> Ship
+  Mutations --> Drizzle
+  Ship --> Drizzle
+  Drizzle --> SQLite
+```
+
+### Shared API contracts
+
+**Zod schemas** in `src/api/*.schemas.ts` define request/response shapes. Client hooks in `src/api/users.ts` parse JSON with these schemas; the server imports the same schemas where validation must stay aligned (for example ship-verify). This reduces drift between UI and API.
+
+### Quality gates and tests
+
+| Layer | How it is checked |
+|--------|-------------------|
+| Client | **Vitest** + RTL (`src/**/*.test.tsx`, coverage gates in `vite.config.ts`), **MSW** for API in tests |
+| E2E | **Playwright** (`pnpm test:e2e`) |
+| Repo health | **Biome** + **oxlint**, **Fallow** audit (`pnpm verify` runs `scripts/verify.sh`) |
+
+Server-only and script code are exercised by targeted tests and manual **drizzle-db-verify** flows when DB/API behavior changes (`CLAUDE.md`).
+
+### Repository layout
+
+| Path | Role |
+|------|------|
+| `src/` | SPA: router, pages, UI, TanStack Query hooks, Zod schemas, mocks |
+| `server/` | Hono app, request handlers, SQLite/Drizzle helpers |
+| `db/` | Drizzle schema, DB factory, seed data |
+| `drizzle/` | Generated SQL migrations |
+| `data/` | Local SQLite file (gitignored) |
+| `scripts/` | `verify`, dev helpers, tooling (e.g. patch-coverage) |
+| `.ai-rules/` | Canonical AI rules, skills, commands, agents (`postinstall` symlinks `.cursor`/`.claude`) |
+
 ## AI workflow (short)
 
 | Goal | Command |


### PR DESCRIPTION
## Summary

- Expand root **README** with an **Architecture** section: dev topology (Vite, MSW, Hono, SQLite), client layers (TanStack Router, Query, Zustand, Zod), server/data, shared contracts, quality gates, and repository layout—using mermaid diagrams.
- Add canonical **babysit** artifacts under **`.ai-rules/`**: optional **`rules/babysit.mdc`**, **`skills/babysit/SKILL.md`** (merge-ready loop vs **fix-comments**), and index updates in **`.ai-rules/README.md`**.

## Test plan

- [x] `pnpm verify` not required for markdown-only + ai-rules text; `postinstall` symlinks unchanged in structure
- [ ] Reviewer: skim README rendering and new rule/skill paths


Made with [Cursor](https://cursor.com)