### PR TITLE
chore(mcp): remove github MCP server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,12 +1,5 @@
 {
   "mcpServers": {
-    "github": {
-      "type": "http",
-      "url": "https://api.githubcopilot.com/mcp/",
-      "headers": {
-        "Authorization": "Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}"
-      }
-    },
     "chrome-devtools": {
       "type": "stdio",
       "command": "npx",


### PR DESCRIPTION
## Summary
- Removes the `github` MCP server from `.mcp.json`
- `gh` CLI covers all the same GitHub operations (PRs, issues, reviews, file contents, branches)
- The `GITHUB_PERSONAL_ACCESS_TOKEN` env var was never set and the server was unused

## Test plan
- [ ] `/doctor` no longer warns about missing `GITHUB_PERSONAL_ACCESS_TOKEN`
- [ ] GitHub operations continue to work via `gh` CLI

## Coverage
No code changes — no coverage impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)