### PR TITLE
fix(appshell): set header height to 69px

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,27 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "npm",
+      "script": "dev",
+      "problemMatcher": [],
+      "label": "npm: dev",
+      "detail": "concurrently -k -n api,vite -c blue,magenta \"pnpm run dev:api\" \"vite\""
+    },
+    {
+      "type": "npm",
+      "script": "install",
+      "group": "clean",
+      "problemMatcher": [],
+      "label": "npm: install",
+      "detail": "install dependencies from package"
+    },
+    {
+      "type": "npm",
+      "script": "verify",
+      "problemMatcher": [],
+      "label": "npm: verify",
+      "detail": "bash scripts/verify.sh"
+    }
+  ]
+}

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -79,7 +79,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       </Sidebar>
       <SidebarInset>
         <header
-          className="flex h-14 shrink-0 items-center gap-2 border-b bg-background/95 px-2 backdrop-blur supports-backdrop-filter:bg-background/60 md:px-4"
+          className="flex h-[69px] shrink-0 items-center gap-2 border-b bg-background/95 px-2 backdrop-blur supports-backdrop-filter:bg-background/60 md:px-4"
           role="banner"
         >
           <SidebarTrigger className="md:-ml-1" />


### PR DESCRIPTION
## Summary
- Changes `h-14` (56px) to `h-[69px]` in `AppShell` header to match intended design height

## Test plan
- [ ] Visual check: header height looks correct in the app
- [ ] No layout regressions in sidebar/content area

## Coverage
No logic changes — UI-only tweak, existing coverage unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)