### PR TITLE
chore(ai-rules): prefer GitHub CLI for PR and API work

### DIFF
--- a/.ai-rules/rules/babysit.mdc
+++ b/.ai-rules/rules/babysit.mdc
@@ -7,7 +7,7 @@ alwaysApply: false
 
 When the user wants to **babysit** a PR or keep a branch **merge-ready**:
 
-- Use **`gh`** (and GitHub MCP if available) for PR state and CI.
+- Use **`gh`** for PR state and CI; GitHub MCP only when **`gh`** cannot perform the operation.
 - **CI:** align fixes with root **`CLAUDE.md`**; run **`pnpm verify`** locally when debugging failures.
 - **Conflicts:** sync with base; resolve only when the right resolution is clear—otherwise ask.
 - **Comments:** address actionable feedback; skip or dispute low-value items with a short note. For GitHub **review threads**, structured replies, and “which comments to implement,” use **`.ai-rules/skills/fix-comments/SKILL.md`**.

--- a/.ai-rules/skills/babysit/SKILL.md
+++ b/.ai-rules/skills/babysit/SKILL.md
@@ -22,4 +22,4 @@ Get the current PR to a **merge-ready** state: CI matches **`CLAUDE.md` / `pnpm 
 4. **CI** — Reproduce locally when possible (`pnpm verify` for this repo). Small, scoped commits; push and re-check CI until green.
 5. **Stop** — When checks pass, branch is up to date, and open feedback is addressed or explicitly deferred.
 
-**Need:** `gh auth login`; GitHub MCP optional. Follow **commit** skill for push / force-with-lease policy on shared branches.
+**Need:** `gh auth login`. **GitHub:** prefer **`gh`** for PR state, checks, and comments; GitHub MCP only if `gh` cannot do the task. Follow **commit** skill for push / force-with-lease policy on shared branches.

--- a/.ai-rules/skills/branch-finishing/SKILL.md
+++ b/.ai-rules/skills/branch-finishing/SKILL.md
@@ -20,7 +20,7 @@ This skill is for branch-level readiness. For git safety, commit grouping, push,
 5. **Fallow** — run Fallow MCP audit or `pnpm fallow audit`; fix `fail`, report `warn`.
 6. **Evidence** — collect verification notes and screenshot paths for UI work. Do not commit verification PNGs unless asked.
 7. **Commit readiness** — use `commit` skill to group changes into buildable commits and avoid unrelated files.
-8. **PR readiness** — push/update the branch and create/update the PR with Summary and Verification sections.
+8. **PR readiness** — push/update the branch; create or update the PR with **`gh`** (`gh pr create`, `gh pr view`, `gh pr edit`) and Summary + Verification sections.
 9. **Clean exit** — end with clean `git status -s` or clearly report remaining intentional changes.
 
 ## PR Body Shape

--- a/.ai-rules/skills/commit/SKILL.md
+++ b/.ai-rules/skills/commit/SKILL.md
@@ -3,6 +3,8 @@ name: commit
 description: Create commits, push, open PR. Git-only.
 ---
 
+**GitHub:** Prefer **`gh`** for PRs and GitHub API calls. Do not reach for GitHub MCP when `gh pr` / `gh api` suffices.
+
 ## Safety (read first)
 
 - **Merged PR / branch:** Do not add commits on a branch whose PR is already merged. The pre-commit hook (`scripts/precommit-merged-pr-guard.sh`) blocks that (via `gh` when available). Create a new branch from `main`: `git fetch origin && git switch -c <user>/<topic> origin/main`. One-off bypass: `SKIP_MERGED_BRANCH_GUARD=1 git commit` (avoid for normal work).

--- a/.ai-rules/skills/fix-comments/SKILL.md
+++ b/.ai-rules/skills/fix-comments/SKILL.md
@@ -2,19 +2,19 @@
 name: fix-comments
 description: >-
   Address GitHub PR review: gather unresolved feedback, TODO list, implement selected
-  items, thread replies. Needs `gh` (and optionally GitHub MCP).
+  items, thread replies. Requires GitHub CLI (`gh`).
 ---
 
 # Fix PR comments
 
-**Need:** `gh` installed and `gh auth login`. Prefer GitHub MCP when present; else `gh api` / `gh pr`.
+**Need:** `gh` installed and `gh auth login`. **Prefer `gh`** for every GitHub operation (`gh pr`, `gh api`, GraphQL via `gh api graphql`). Use GitHub MCP only when `gh` cannot do the job.
 
 **Rules:** Threaded replies to the **original** thread. **Conventional Comments** + response labels (below). **Do not** post to GitHub until the user approves draft replies. Praise/LGTM/non-actionable → skip (no TODO, no reply).
 
 ## 1) Find PR and collect **unresolved** only
 
 - PR: `gh pr view --json number` or ask once for number. Owner/repo: `gh repo view --json nameWithOwner`. Base: `gh pr view <n> --json baseRefName`.
-- Sources: (a) issue comments on the PR, (b) review threads (`isResolved: false` only), (c) review bodies worth acting on. Use MCP `pull_request_read` or `gh api` / GraphQL — **exclude** `isResolved: true` and **praise / thanks / LGTM** with no request.
+- Sources: (a) issue comments on the PR, (b) review threads (`isResolved: false` only), (c) review bodies worth acting on. Collect via **`gh api`** / `gh api graphql` (see Reference) — **exclude** `isResolved: true` and **praise / thanks / LGTM** with no request.
 - De-dupe; flag `isOutdated` as low priority.
 
 **Per item store:** `source_type` (issue / inline / review), stable `id` (REST `databaseId` for inline), `body`, `path:line` if any, `author`, `url`, `isOutdated`.
@@ -55,9 +55,13 @@ Ask: **“Which ids should I implement?”** and wait. Then implement **only** s
 
 ## 7) Post (after user confirms)
 
-- **Inline:** MCP `add_reply_to_pull_request_comment` or  
-  `gh api -X POST repos/{o}/{r}/pulls/{pr}/comments/{databaseId}/replies -f body='...'`
-- **Issue comment:** `gh pr comment` / MCP equivalent for top-level.
+- **Inline (threaded reply to a review comment):** **`gh api`** using the REST path that includes the **PR number**:
+  ```bash
+  gh api -X POST repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id}/replies -f body='...'
+  ```
+  Use the PR you are on (`gh pr view --json number`) for `{pr_number}`. For `{comment_id}`, use the thread’s REST id — same value as GraphQL `databaseId` (or `gh api repos/{owner}/{repo}/pulls/{pr_number}/comments --jq '.[].id'`).
+  **404 trap:** `repos/{owner}/{repo}/pulls/comments/{comment_id}/replies` **omits** `{pr_number}` and is **not** a valid endpoint; GitHub returns Not Found.
+- **Issue comment (PR conversation):** `gh pr comment` or `gh api -X POST repos/{owner}/{repo}/issues/{pr_number}/comments -f body='...'`.
 
 Reply text: one tight paragraph; link what changed. Don’t thread-reply to your own comments unless it helps reviewers.
 


### PR DESCRIPTION
## Summary

- Document that **`gh`** is the default for GitHub (PR view/create, `gh api`, GraphQL via `gh api graphql`), with GitHub MCP only when `gh` is insufficient.
- Touches **fix-comments**, **commit**, **branch-finishing**, **babysit** skill, and **babysit** Cursor rule.

## Test plan

- [ ] N/A (agent rules / skills only)

## Coverage

- N/A

Made with [Cursor](https://cursor.com)