### PR TITLE
feat(users): per-user OTU payment methods with masked card UI

### DIFF
--- a/db/schema.ts
+++ b/db/schema.ts
@@ -1,4 +1,4 @@
-import { sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 
 export const users = sqliteTable("users", {
   id: text("id").primaryKey(),
@@ -7,4 +7,24 @@ export const users = sqliteTable("users", {
   role: text("role", { enum: ["admin", "member"] }).notNull(),
 });
 
+/**
+ * One-time-use / issued card records for this payment product.
+ * Full PAN is stored for demo/local SQLite; production must use encryption at rest,
+ * key management, and PCI-aligned controls (vault/HSM, access audit, retention).
+ */
+export const paymentMethods = sqliteTable("payment_methods", {
+  id: text("id").primaryKey(),
+  userId: text("user_id")
+    .notNull()
+    .references(() => users.id, { onDelete: "cascade" }),
+  brand: text("brand", { enum: ["visa", "mastercard", "amex", "unknown"] }).notNull(),
+  /** Full card number (OTU issued cards). Do not log or expose outside trusted UI/API. */
+  cardNumber: text("card_number").notNull(),
+  cvv: text("cvv").notNull(),
+  label: text("label"),
+  expMonth: integer("exp_month"),
+  expYear: integer("exp_year"),
+});
+
 export type UserRow = typeof users.$inferSelect;
+export type PaymentMethodRow = typeof paymentMethods.$inferSelect;

--- a/db/seed-data.ts
+++ b/db/seed-data.ts
@@ -1,9 +1,45 @@
+import type { PaymentMethod } from "../src/api/paymentMethods.schemas";
 import type { User } from "../src/api/users.schemas";
+import { DEMO_ALICE_USER_ID } from "../src/demo/constants";
+
+/** OTU / issued test PANs (Stripe-style test numbers; not real cards). */
+export const seedPaymentMethods: PaymentMethod[] = [
+  {
+    id: "660e8400-e29b-41d4-a716-446655440001",
+    userId: DEMO_ALICE_USER_ID,
+    brand: "visa",
+    cardNumber: "4242424242424242",
+    cvv: "123",
+    label: "OTU — vendor checkout A",
+    expMonth: 12,
+    expYear: 2030,
+  },
+  {
+    id: "660e8400-e29b-41d4-a716-446655440002",
+    userId: DEMO_ALICE_USER_ID,
+    brand: "mastercard",
+    cardNumber: "5555555555554444",
+    cvv: "456",
+    label: "OTU — vendor checkout B",
+    expMonth: 6,
+    expYear: 2029,
+  },
+  {
+    id: "660e8400-e29b-41d4-a716-446655440003",
+    userId: "550e8400-e29b-41d4-a716-446655440002",
+    brand: "visa",
+    cardNumber: "4000000000000077",
+    cvv: "789",
+    label: "OTU — Bob",
+    expMonth: 3,
+    expYear: 2028,
+  },
+];
 
 /** Shared source of truth for MSW tests and SQLite seeding. */
 export const seedUsers: User[] = [
   {
-    id: "550e8400-e29b-41d4-a716-446655440001",
+    id: DEMO_ALICE_USER_ID,
     name: "Alice Admin",
     email: "alice@example.com",
     role: "admin",

--- a/drizzle/0001_payment_methods.sql
+++ b/drizzle/0001_payment_methods.sql
@@ -1,0 +1,10 @@
+CREATE TABLE `payment_methods` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`brand` text NOT NULL,
+	`card_number` text NOT NULL,
+	`label` text,
+	`exp_month` integer,
+	`exp_year` integer,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);

--- a/drizzle/0002_rebuild_payment_methods_card_number.sql
+++ b/drizzle/0002_rebuild_payment_methods_card_number.sql
@@ -1,0 +1,14 @@
+-- Fix DBs that ran an older 0001 with `last4` instead of `card_number`.
+-- Clears payment_methods; server startup re-seeds when the table is empty.
+DROP TABLE IF EXISTS `payment_methods`;
+--> statement-breakpoint
+CREATE TABLE `payment_methods` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`brand` text NOT NULL,
+	`card_number` text NOT NULL,
+	`label` text,
+	`exp_month` integer,
+	`exp_year` integer,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);

--- a/drizzle/0003_payment_methods_cvv.sql
+++ b/drizzle/0003_payment_methods_cvv.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `payment_methods` ADD `cvv` text NOT NULL DEFAULT '000';

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,131 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "c01da521-bdec-4356-b36b-df02027295b0",
+  "prevId": "fce0fba2-7048-47bc-92ca-f54b8a73c114",
+  "tables": {
+    "payment_methods": {
+      "name": "payment_methods",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "card_number": {
+          "name": "card_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exp_month": {
+          "name": "exp_month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exp_year": {
+          "name": "exp_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "payment_methods_user_id_users_id_fk": {
+          "name": "payment_methods_user_id_users_id_fk",
+          "tableFrom": "payment_methods",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,131 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "e91da521-bdec-4356-b36b-df02027295c0",
+  "prevId": "c01da521-bdec-4356-b36b-df02027295b0",
+  "tables": {
+    "payment_methods": {
+      "name": "payment_methods",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "card_number": {
+          "name": "card_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exp_month": {
+          "name": "exp_month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exp_year": {
+          "name": "exp_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "payment_methods_user_id_users_id_fk": {
+          "name": "payment_methods_user_id_users_id_fk",
+          "tableFrom": "payment_methods",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,138 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "f91da521-bdec-4356-b36b-df02027295d0",
+  "prevId": "e91da521-bdec-4356-b36b-df02027295c0",
+  "tables": {
+    "payment_methods": {
+      "name": "payment_methods",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "card_number": {
+          "name": "card_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cvv": {
+          "name": "cvv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exp_month": {
+          "name": "exp_month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exp_year": {
+          "name": "exp_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "payment_methods_user_id_users_id_fk": {
+          "name": "payment_methods_user_id_users_id_fk",
+          "tableFrom": "payment_methods",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,27 @@
       "when": 1776909207827,
       "tag": "0000_faithful_lilith",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1777255064663,
+      "tag": "0001_payment_methods",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1777255200000,
+      "tag": "0002_rebuild_payment_methods_card_number",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1777255300000,
+      "tag": "0003_payment_methods_cvv",
+      "breakpoints": true
     }
   ]
 }

--- a/server/ensureDemoSeed.ts
+++ b/server/ensureDemoSeed.ts
@@ -1,0 +1,40 @@
+import { count, eq } from "drizzle-orm";
+import type { Db } from "../db/client";
+import { paymentMethods, users } from "../db/schema";
+import { seedPaymentMethods, seedUsers } from "../db/seed-data";
+
+function ensureSeedUsers(db: Db): void {
+  for (const u of seedUsers) {
+    const byId = db.select().from(users).where(eq(users.id, u.id)).get();
+    if (byId) continue;
+    const byEmail = db.select().from(users).where(eq(users.email, u.email)).get();
+    if (byEmail) continue;
+    db.insert(users).values(u).run();
+  }
+}
+
+function ensureSeedPaymentMethods(db: Db): void {
+  const pmCountRow = db.select({ c: count() }).from(paymentMethods).get();
+  if ((pmCountRow?.c ?? 0) > 0) return;
+
+  const userIds = new Set(
+    db
+      .select({ id: users.id })
+      .from(users)
+      .all()
+      .map((r) => r.id)
+  );
+  const rows = seedPaymentMethods.filter((pm) => userIds.has(pm.userId));
+  if (rows.length > 0) {
+    db.insert(paymentMethods).values(rows).run();
+  }
+}
+
+/**
+ * Idempotent demo seed: add missing fixture users (by id), then payment methods
+ * when the table is empty. Skips a user if their email is already taken by another row.
+ */
+export function ensureDemoSeed(db: Db): void {
+  ensureSeedUsers(db);
+  ensureSeedPaymentMethods(db);
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,12 +1,12 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { serve } from "@hono/node-server";
-import { count, eq } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { migrate } from "drizzle-orm/better-sqlite3/migrator";
 import { Hono } from "hono";
 import { createDb } from "../db/client";
-import { users } from "../db/schema";
-import { seedUsers } from "../db/seed-data";
+import { paymentMethods, users } from "../db/schema";
+import { ensureDemoSeed } from "./ensureDemoSeed";
 import { getShipVerifyResponse } from "./shipVerify";
 import { existingUserForIdParam } from "./userLookup";
 import { handlePatchUser, handlePostUser } from "./userMutations";
@@ -16,11 +16,7 @@ const migrationsFolder = path.join(__dirname, "../drizzle");
 
 const db = createDb();
 migrate(db, { migrationsFolder });
-
-const countRow = db.select({ c: count() }).from(users).get();
-if ((countRow?.c ?? 0) === 0) {
-  db.insert(users).values(seedUsers).run();
-}
+ensureDemoSeed(db);
 
 const app = new Hono();
 
@@ -34,6 +30,17 @@ app.get("/api/ship-verify", (c) => {
 
 app.get("/api/users", (c) => {
   const rows = db.select().from(users).all();
+  return c.json(rows);
+});
+
+app.get("/api/users/:userId/payment-methods", (c) => {
+  const resolved = existingUserForIdParam(c, db, c.req.param("userId"));
+  if ("response" in resolved) return resolved.response;
+  const rows = db
+    .select()
+    .from(paymentMethods)
+    .where(eq(paymentMethods.userId, resolved.user.id))
+    .all();
   return c.json(rows);
 });
 

--- a/src/api/paymentMethods.schemas.ts
+++ b/src/api/paymentMethods.schemas.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+const PaymentMethodBrandSchema = z.enum(["visa", "mastercard", "amex", "unknown"]);
+
+/** 12–19 digits per ISO/IEC 7812; Luhn optional for tests (issuer-generated OTU may vary). */
+const CardNumberSchema = z.string().regex(/^\d{12,19}$/, "card number must be 12–19 digits");
+
+const CvvSchema = z.string().regex(/^\d{3,4}$/, "CVV must be 3 or 4 digits");
+
+const PaymentMethodSchema = z.object({
+  id: z.string().uuid(),
+  userId: z.string().uuid(),
+  brand: PaymentMethodBrandSchema,
+  cardNumber: CardNumberSchema,
+  cvv: CvvSchema,
+  label: z.string().nullable(),
+  expMonth: z.number().int().min(1).max(12).nullable(),
+  expYear: z.number().int().min(2000).max(2100).nullable(),
+});
+
+export const PaymentMethodsListSchema = z.array(PaymentMethodSchema);
+
+export type PaymentMethod = z.infer<typeof PaymentMethodSchema>;

--- a/src/api/paymentMethods.test.tsx
+++ b/src/api/paymentMethods.test.tsx
@@ -1,0 +1,66 @@
+import { type QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import type { ReactNode } from "react";
+import { describe, expect, it } from "vitest";
+import { ZodError } from "zod";
+import { DEMO_ALICE_USER_ID } from "../demo/constants";
+import { server } from "../mocks/server";
+import { createTestQueryClient } from "../test/utils";
+import { fetchPaymentMethods, queryKeys, usePaymentMethods } from "./paymentMethods";
+
+function wrapper(queryClient: QueryClient) {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe("queryKeys.paymentMethods.byUser", () => {
+  it("scopes by user id", () => {
+    expect(queryKeys.paymentMethods.byUser("abc")).toEqual(["payment-methods", "abc"]);
+  });
+});
+
+describe("fetchPaymentMethods", () => {
+  it("returns parsed payment methods", async () => {
+    const list = await fetchPaymentMethods(DEMO_ALICE_USER_ID);
+    expect(list.length).toBeGreaterThan(0);
+    expect(list[0]).toMatchObject({
+      id: expect.any(String),
+      userId: DEMO_ALICE_USER_ID,
+      brand: expect.stringMatching(/^(visa|mastercard|amex|unknown)$/),
+      cardNumber: expect.stringMatching(/^\d{12,19}$/),
+      cvv: expect.stringMatching(/^\d{3,4}$/),
+    });
+  });
+
+  it("throws on 500", async () => {
+    server.use(
+      http.get("/api/users/:userId/payment-methods", () => new HttpResponse(null, { status: 500 }))
+    );
+    await expect(fetchPaymentMethods(DEMO_ALICE_USER_ID)).rejects.toThrow(/HTTP 500/);
+  });
+
+  it("throws on 404", async () => {
+    const missing = "00000000-0000-4000-8000-000000000099";
+    await expect(fetchPaymentMethods(missing)).rejects.toThrow(/not found/i);
+  });
+
+  it("throws ZodError on malformed JSON", async () => {
+    server.use(
+      http.get("/api/users/:userId/payment-methods", () => HttpResponse.json([{ broken: true }]))
+    );
+    await expect(fetchPaymentMethods(DEMO_ALICE_USER_ID)).rejects.toBeInstanceOf(ZodError);
+  });
+});
+
+describe("usePaymentMethods", () => {
+  it("resolves with data", async () => {
+    const qc = createTestQueryClient();
+    const { result } = renderHook(() => usePaymentMethods(DEMO_ALICE_USER_ID), {
+      wrapper: wrapper(qc),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.length).toBeGreaterThan(0);
+  });
+});

--- a/src/api/paymentMethods.ts
+++ b/src/api/paymentMethods.ts
@@ -1,0 +1,34 @@
+import { useQuery } from "@tanstack/react-query";
+import { type PaymentMethod, PaymentMethodsListSchema } from "./paymentMethods.schemas";
+
+export const queryKeys = {
+  paymentMethods: {
+    byUser: (userId: string) => ["payment-methods", userId] as const,
+  },
+} as const;
+
+export async function fetchPaymentMethods(userId: string): Promise<PaymentMethod[]> {
+  const res = await fetch(`/api/users/${encodeURIComponent(userId)}/payment-methods`);
+  if (res.status === 404) {
+    const errText = await res.text();
+    let message = "User not found.";
+    try {
+      const j = JSON.parse(errText) as { error?: string };
+      if (j.error) message = j.error;
+    } catch {
+      // keep default
+    }
+    throw new Error(message);
+  }
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const json = await res.json();
+  return PaymentMethodsListSchema.parse(json);
+}
+
+export function usePaymentMethods(userId: string) {
+  return useQuery({
+    queryKey: queryKeys.paymentMethods.byUser(userId),
+    queryFn: () => fetchPaymentMethods(userId),
+    enabled: Boolean(userId),
+  });
+}

--- a/src/components/OtuPaymentMethodCard.test.tsx
+++ b/src/components/OtuPaymentMethodCard.test.tsx
@@ -1,0 +1,53 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { renderWithProviders } from "../test/utils";
+import { OtuPaymentMethodCard } from "./OtuPaymentMethodCard";
+
+const pm = {
+  id: "660e8400-e29b-41d4-a716-446655440001",
+  userId: "550e8400-e29b-41d4-a716-446655440001",
+  brand: "visa" as const,
+  cardNumber: "4242424242424242",
+  cvv: "123",
+  label: "OTU — vendor checkout A",
+  expMonth: 12,
+  expYear: 2030,
+};
+
+describe("OtuPaymentMethodCard", () => {
+  it("masks PAN, CVV, and expiry until Show", () => {
+    renderWithProviders(
+      <OtuPaymentMethodCard
+        pm={pm}
+        copiedId={null}
+        onCopy={vi.fn<(id: string, cardNumber: string) => void>()}
+      />
+    );
+
+    expect(screen.getByText("•••• •••• •••• ••••")).toBeInTheDocument();
+    expect(screen.getByText("•••", { exact: true })).toBeInTheDocument();
+    expect(screen.getByText("••/••")).toBeInTheDocument();
+    expect(screen.queryByText("4242 4242 4242 4242")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /copy card number/i })).not.toBeInTheDocument();
+  });
+
+  it("Show reveals values and Copy; Hide masks again", async () => {
+    const user = userEvent.setup();
+    const onCopy = vi.fn<(id: string, cardNumber: string) => void>();
+    renderWithProviders(<OtuPaymentMethodCard pm={pm} copiedId={null} onCopy={onCopy} />);
+
+    await user.click(screen.getByRole("button", { name: /^show$/i }));
+
+    expect(screen.getByText("4242 4242 4242 4242")).toBeInTheDocument();
+    expect(screen.getByText("123")).toBeInTheDocument();
+    expect(screen.getByText("12/30")).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: /copy card number/i })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /^hide$/i }));
+
+    expect(screen.queryByText("4242 4242 4242 4242")).not.toBeInTheDocument();
+    expect(screen.getByText("•••• •••• •••• ••••")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /copy card number/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/components/OtuPaymentMethodCard.tsx
+++ b/src/components/OtuPaymentMethodCard.tsx
@@ -1,0 +1,140 @@
+import type { PaymentMethod } from "@/api/paymentMethods.schemas";
+import { Button } from "@/components/ui/button";
+import { formatPanGroups, maskPanFully } from "@/lib/maskCardNumber";
+import { cn } from "@/lib/utils";
+import { useState } from "react";
+
+const brandFaceClass: Record<PaymentMethod["brand"], string> = {
+  visa: cn(
+    "border-l-[3px] border-l-sky-500/55",
+    "bg-gradient-to-br from-sky-50/90 via-card to-card",
+    "dark:from-sky-950/45 dark:via-card dark:to-card dark:border-l-sky-400/45"
+  ),
+  mastercard: cn(
+    "border-l-[3px] border-l-orange-500/50",
+    "bg-gradient-to-br from-orange-50/80 via-card to-card",
+    "dark:from-orange-950/35 dark:via-card dark:to-card dark:border-l-orange-400/40"
+  ),
+  amex: cn(
+    "border-l-[3px] border-l-emerald-600/50",
+    "bg-gradient-to-br from-emerald-50/75 via-card to-card",
+    "dark:from-emerald-950/40 dark:via-card dark:to-card dark:border-l-emerald-400/40"
+  ),
+  unknown: cn(
+    "border-l-[3px] border-l-muted-foreground/30",
+    "bg-gradient-to-br from-muted/50 via-card to-card",
+    "dark:from-muted/25 dark:via-card dark:to-card"
+  ),
+};
+
+interface OtuPaymentMethodCardProps {
+  pm: PaymentMethod;
+  copiedId: string | null;
+  onCopy: (id: string, cardNumber: string) => void;
+}
+
+function cardExpiryShort(pm: PaymentMethod): string | null {
+  if (pm.expMonth == null || pm.expYear == null) return null;
+  const yy = String(pm.expYear).slice(-2);
+  return `${String(pm.expMonth).padStart(2, "0")}/${yy}`;
+}
+
+function maskCvv(cvv: string): string {
+  return cvv.replace(/\d/g, "•");
+}
+
+export function OtuPaymentMethodCard({ pm, copiedId, onCopy }: OtuPaymentMethodCardProps) {
+  const exp = cardExpiryShort(pm);
+  const [sensitiveVisible, setSensitiveVisible] = useState(false);
+
+  const expDisplay = exp == null ? "—" : sensitiveVisible ? exp : "••/••";
+
+  const cvvDisplay = sensitiveVisible ? pm.cvv : maskCvv(pm.cvv);
+
+  return (
+    <div className="flex w-full max-w-sm flex-col gap-2">
+      <div
+        className={cn(
+          "relative w-full overflow-hidden rounded-2xl border border-border bg-card text-card-foreground shadow-sm",
+          "aspect-[1.586] max-h-[220px] min-h-[180px]",
+          "shadow-[inset_0_1px_0_0_rgba(255,255,255,0.65)] dark:shadow-[inset_0_1px_0_0_rgba(255,255,255,0.06)]",
+          brandFaceClass[pm.brand]
+        )}
+      >
+        <span
+          className="pointer-events-none absolute inset-0 rounded-2xl bg-[radial-gradient(120%_90%_at_100%_0%,var(--muted-foreground)_0%,transparent_58%)] opacity-[0.14] dark:opacity-[0.09]"
+          aria-hidden
+        />
+        <div className="relative flex h-full flex-col p-4 pt-3.5">
+          <div className="flex items-start justify-between gap-2">
+            <div
+              className="h-7 w-10 shrink-0 rounded-md border border-amber-700/15 bg-gradient-to-br from-amber-100 to-amber-200/90 shadow-[inset_0_1px_1px_rgba(255,255,255,0.7)] dark:border-amber-500/20 dark:from-amber-900/70 dark:to-amber-950/90 dark:shadow-[inset_0_1px_1px_rgba(0,0,0,0.35)]"
+              aria-hidden
+            />
+            <span className="rounded-full border border-border/80 bg-secondary/80 px-2 py-0.5 text-xs font-medium capitalize text-secondary-foreground">
+              {pm.brand}
+            </span>
+          </div>
+
+          {pm.label ? (
+            <p className="text-muted-foreground mt-2 truncate text-xs">{pm.label}</p>
+          ) : null}
+
+          <div className="mt-auto space-y-3">
+            <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+              <p className="min-w-0 flex-1 font-mono text-[clamp(0.8rem,2.8vw,1rem)] leading-snug tracking-[0.12em] text-foreground">
+                {sensitiveVisible ? formatPanGroups(pm.cardNumber) : maskPanFully(pm.cardNumber)}
+              </p>
+              <Button
+                type="button"
+                variant="link"
+                size="sm"
+                className="text-foreground h-auto shrink-0 px-1 py-0 text-sm font-medium underline-offset-4 hover:underline"
+                aria-expanded={sensitiveVisible}
+                aria-controls={`otu-card-sensitive-${pm.id}`}
+                onClick={() => setSensitiveVisible((v) => !v)}
+              >
+                {sensitiveVisible ? "Hide" : "Show"}
+              </Button>
+            </div>
+
+            <div
+              id={`otu-card-sensitive-${pm.id}`}
+              className="flex items-end justify-between gap-4"
+              aria-live="polite"
+            >
+              <div>
+                <p className="text-[0.65rem] font-medium uppercase tracking-wider text-muted-foreground">
+                  Expires
+                </p>
+                <p className="font-mono text-sm font-medium tabular-nums text-foreground">
+                  {expDisplay}
+                </p>
+              </div>
+              <div className="text-right">
+                <p className="text-[0.65rem] font-medium uppercase tracking-wider text-muted-foreground">
+                  CVV
+                </p>
+                <p className="font-mono text-sm font-medium tabular-nums text-foreground">
+                  {cvvDisplay}
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {sensitiveVisible ? (
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          className="w-full"
+          onClick={() => void onCopy(pm.id, pm.cardNumber)}
+        >
+          {copiedId === pm.id ? "Copied" : "Copy card number"}
+        </Button>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/UserCard.tsx
+++ b/src/components/UserCard.tsx
@@ -5,22 +5,17 @@ interface UserCardProps {
   user: User;
 }
 
-export function UserCard({ user }: UserCardProps) {
-  const [editing, setEditing] = useState(false);
+function UserCardEditForm({ user, onClose }: { user: User; onClose: () => void }) {
   const [name, setName] = useState(user.name);
   const [email, setEmail] = useState(user.email);
   const [role, setRole] = useState<"admin" | "member">(user.role);
-
   const updateUser = useUpdateUser();
-  const deleteUser = useDeleteUser();
 
   useEffect(() => {
-    if (!editing) {
-      setName(user.name);
-      setEmail(user.email);
-      setRole(user.role);
-    }
-  }, [user, editing]);
+    setName(user.name);
+    setEmail(user.email);
+    setRole(user.role);
+  }, [user]);
 
   async function onSave(e: FormEvent) {
     e.preventDefault();
@@ -30,11 +25,106 @@ export function UserCard({ user }: UserCardProps) {
         id: user.id,
         body: { name, email, role },
       });
-      setEditing(false);
+      onClose();
     } catch {
       // error shown via updateUser.error
     }
   }
+
+  function onCancel() {
+    updateUser.reset();
+    setName(user.name);
+    setEmail(user.email);
+    setRole(user.role);
+    onClose();
+  }
+
+  return (
+    <form
+      onSubmit={(e) => {
+        void onSave(e);
+      }}
+      className="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800"
+      aria-label={`Edit user ${user.name}`}
+    >
+      <div className="grid gap-2 sm:grid-cols-2">
+        <div>
+          <label
+            htmlFor={`edit-name-${user.id}`}
+            className="mb-0.5 block text-xs text-gray-600 dark:text-gray-400"
+          >
+            Name
+          </label>
+          <input
+            id={`edit-name-${user.id}`}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+            className="w-full rounded border border-gray-300 px-2 py-1 text-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white"
+          />
+        </div>
+        <div>
+          <label
+            htmlFor={`edit-email-${user.id}`}
+            className="mb-0.5 block text-xs text-gray-600 dark:text-gray-400"
+          >
+            Email
+          </label>
+          <input
+            id={`edit-email-${user.id}`}
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            className="w-full rounded border border-gray-300 px-2 py-1 text-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white"
+          />
+        </div>
+        <div>
+          <label
+            htmlFor={`edit-role-${user.id}`}
+            className="mb-0.5 block text-xs text-gray-600 dark:text-gray-400"
+          >
+            Role
+          </label>
+          <select
+            id={`edit-role-${user.id}`}
+            value={role}
+            onChange={(e) => setRole(e.target.value as "admin" | "member")}
+            className="w-full rounded border border-gray-300 px-2 py-1 text-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white"
+          >
+            <option value="member">member</option>
+            <option value="admin">admin</option>
+          </select>
+        </div>
+      </div>
+      {updateUser.error ? (
+        <p role="alert" className="mt-2 text-sm text-red-600 dark:text-red-400">
+          {updateUser.error instanceof Error ? updateUser.error.message : "Update failed."}
+        </p>
+      ) : null}
+      <div className="mt-3 flex flex-wrap gap-2">
+        <button
+          type="submit"
+          disabled={updateUser.isPending}
+          className="rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          {updateUser.isPending ? "Saving…" : "Save"}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded border border-gray-300 px-3 py-1 text-sm hover:bg-gray-100 dark:border-gray-600 dark:hover:bg-gray-700"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}
+
+export function UserCard({ user }: UserCardProps) {
+  const [editing, setEditing] = useState(false);
+  const deleteUser = useDeleteUser();
 
   function onDelete() {
     if (!globalThis.confirm(`Delete ${user.name}? This cannot be undone.`)) return;
@@ -43,93 +133,7 @@ export function UserCard({ user }: UserCardProps) {
   }
 
   if (editing) {
-    return (
-      <form
-        onSubmit={(e) => {
-          void onSave(e);
-        }}
-        className="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800"
-        aria-label={`Edit user ${user.name}`}
-      >
-        <div className="grid gap-2 sm:grid-cols-2">
-          <div>
-            <label
-              htmlFor={`edit-name-${user.id}`}
-              className="mb-0.5 block text-xs text-gray-600 dark:text-gray-400"
-            >
-              Name
-            </label>
-            <input
-              id={`edit-name-${user.id}`}
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              required
-              className="w-full rounded border border-gray-300 px-2 py-1 text-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white"
-            />
-          </div>
-          <div>
-            <label
-              htmlFor={`edit-email-${user.id}`}
-              className="mb-0.5 block text-xs text-gray-600 dark:text-gray-400"
-            >
-              Email
-            </label>
-            <input
-              id={`edit-email-${user.id}`}
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              required
-              className="w-full rounded border border-gray-300 px-2 py-1 text-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white"
-            />
-          </div>
-          <div>
-            <label
-              htmlFor={`edit-role-${user.id}`}
-              className="mb-0.5 block text-xs text-gray-600 dark:text-gray-400"
-            >
-              Role
-            </label>
-            <select
-              id={`edit-role-${user.id}`}
-              value={role}
-              onChange={(e) => setRole(e.target.value as "admin" | "member")}
-              className="w-full rounded border border-gray-300 px-2 py-1 text-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white"
-            >
-              <option value="member">member</option>
-              <option value="admin">admin</option>
-            </select>
-          </div>
-        </div>
-        {updateUser.error ? (
-          <p role="alert" className="mt-2 text-sm text-red-600 dark:text-red-400">
-            {updateUser.error instanceof Error ? updateUser.error.message : "Update failed."}
-          </p>
-        ) : null}
-        <div className="mt-3 flex flex-wrap gap-2">
-          <button
-            type="submit"
-            disabled={updateUser.isPending}
-            className="rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
-          >
-            {updateUser.isPending ? "Saving…" : "Save"}
-          </button>
-          <button
-            type="button"
-            onClick={() => {
-              updateUser.reset();
-              setEditing(false);
-              setName(user.name);
-              setEmail(user.email);
-              setRole(user.role);
-            }}
-            className="rounded border border-gray-300 px-3 py-1 text-sm hover:bg-gray-100 dark:border-gray-600 dark:hover:bg-gray-700"
-          >
-            Cancel
-          </button>
-        </div>
-      </form>
-    );
+    return <UserCardEditForm user={user} onClose={() => setEditing(false)} />;
   }
 
   return (
@@ -150,6 +154,12 @@ export function UserCard({ user }: UserCardProps) {
           >
             {user.role}
           </span>
+          <a
+            href={`/users/${encodeURIComponent(user.id)}/payment-methods`}
+            className="rounded border border-gray-300 px-2 py-1 text-sm hover:bg-gray-100 dark:border-gray-600 dark:hover:bg-gray-700"
+          >
+            OTU cards
+          </a>
           <button
             type="button"
             onClick={() => setEditing(true)}

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -13,11 +13,13 @@ import {
   SidebarProvider,
   SidebarTrigger,
 } from "@/components/ui/sidebar";
+import { DEMO_ALICE_USER_ID } from "@/demo/constants";
 import { cn } from "@/lib/utils";
 import { useUiStore } from "@/store/uiStore";
 import { Link, useRouterState } from "@tanstack/react-router";
 import {
   ClipboardList,
+  CreditCard,
   Info,
   LayoutDashboard,
   LayoutGrid,
@@ -28,15 +30,25 @@ import {
 } from "lucide-react";
 import * as React from "react";
 
-const mainNav: { to: string; label: string; icon: React.ComponentType<{ className?: string }> }[] =
-  [
-    { to: "/users", label: "Users", icon: Users },
-    { to: "/playground", label: "Playground", icon: LayoutGrid },
-    { to: "/components-demo", label: "Components", icon: PanelsTopLeft },
-    { to: "/dashboard-demo", label: "Dashboard", icon: LayoutDashboard },
-    { to: "/ship-report", label: "Ship report", icon: ClipboardList },
-    { to: "/about", label: "About", icon: Info },
-  ];
+const mainNav: {
+  to: string;
+  label: string;
+  icon: React.ComponentType<{ className?: string }>;
+  params?: Record<string, string>;
+}[] = [
+  { to: "/users", label: "Users", icon: Users },
+  {
+    to: "/users/$userId/payment-methods",
+    label: "OTU cards",
+    icon: CreditCard,
+    params: { userId: DEMO_ALICE_USER_ID },
+  },
+  { to: "/playground", label: "Playground", icon: LayoutGrid },
+  { to: "/components-demo", label: "Components", icon: PanelsTopLeft },
+  { to: "/dashboard-demo", label: "Dashboard", icon: LayoutDashboard },
+  { to: "/ship-report", label: "Ship report", icon: ClipboardList },
+  { to: "/about", label: "About", icon: Info },
+];
 
 export function AppShell({ children }: { children: React.ReactNode }) {
   const pathname = useRouterState({ select: (s) => s.location.pathname });
@@ -57,14 +69,21 @@ export function AppShell({ children }: { children: React.ReactNode }) {
               <SidebarMenu>
                 {mainNav.map((item) => {
                   const Icon = item.icon;
+                  const isPaymentMethods = item.to.includes("payment-methods");
                   const isActive =
                     item.to === "/"
                       ? pathname === "/"
-                      : pathname === item.to || pathname.startsWith(`${item.to}/`);
+                      : isPaymentMethods
+                        ? pathname.includes("/payment-methods")
+                        : pathname === item.to || pathname.startsWith(`${item.to}/`);
                   return (
-                    <SidebarMenuItem key={item.to}>
+                    <SidebarMenuItem key={`${item.to}-${item.label}`}>
                       <SidebarMenuButton asChild isActive={isActive} tooltip={item.label}>
-                        <Link to={item.to} aria-current={isActive ? "page" : undefined}>
+                        <Link
+                          to={item.to}
+                          params={item.params}
+                          aria-current={isActive ? "page" : undefined}
+                        >
                           <Icon className="size-4" />
                           <span>{item.label}</span>
                         </Link>

--- a/src/demo/constants.ts
+++ b/src/demo/constants.ts
@@ -1,0 +1,2 @@
+/** Alice (first seed user) — keep in sync with `db/seed-data` / MSW fixtures. */
+export const DEMO_ALICE_USER_ID = "550e8400-e29b-41d4-a716-446655440001";

--- a/src/lib/maskCardNumber.test.ts
+++ b/src/lib/maskCardNumber.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { formatPanGroups, maskCardNumber, maskPanFully } from "./maskCardNumber";
+
+describe("maskCardNumber", () => {
+  it("masks all but last four digits", () => {
+    expect(maskCardNumber("4242424242424242")).toBe("••••••••••••4242");
+  });
+
+  it("returns short strings unchanged", () => {
+    expect(maskCardNumber("4242")).toBe("4242");
+  });
+});
+
+describe("formatPanGroups", () => {
+  it("groups digits in quartets", () => {
+    expect(formatPanGroups("4242424242424242")).toBe("4242 4242 4242 4242");
+  });
+});
+
+describe("maskPanFully", () => {
+  it("keeps grouping but hides all digits", () => {
+    expect(maskPanFully("4242424242424242")).toBe("•••• •••• •••• ••••");
+  });
+});

--- a/src/lib/maskCardNumber.ts
+++ b/src/lib/maskCardNumber.ts
@@ -1,0 +1,16 @@
+/** Mask PAN for on-screen display; copy flow uses the full number separately. */
+export function maskCardNumber(cardNumber: string): string {
+  if (cardNumber.length <= 4) return cardNumber;
+  return `${"•".repeat(cardNumber.length - 4)}${cardNumber.slice(-4)}`;
+}
+
+/** Group PAN digits as spaced quartets (e.g. 4242 4242 4242 4242). */
+export function formatPanGroups(cardNumber: string): string {
+  const digits = cardNumber.replace(/\D/g, "");
+  return digits.replace(/(\d{4})(?=\d)/g, "$1 ").trim();
+}
+
+/** Same grouping as `formatPanGroups`, digits replaced with bullets (nothing revealed). */
+export function maskPanFully(cardNumber: string): string {
+  return formatPanGroups(cardNumber).replace(/\d/g, "•");
+}

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,14 +1,17 @@
 import { http, HttpResponse } from "msw";
-import { seedUsers } from "../../db/seed-data";
+import { seedPaymentMethods, seedUsers } from "../../db/seed-data";
+import type { PaymentMethod } from "../api/paymentMethods.schemas";
 import type { ShipVerifyResponse } from "../api/shipVerify.schemas";
 import type { User } from "../api/users.schemas";
 
 let userList: User[] = seedUsers.map((u) => ({ ...u }));
+let paymentMethodList: PaymentMethod[] = seedPaymentMethods.map((p) => ({ ...p }));
 
 export const userFixtures = seedUsers;
 
 function resetList() {
   userList = seedUsers.map((u) => ({ ...u }));
+  paymentMethodList = seedPaymentMethods.map((p) => ({ ...p }));
 }
 
 export { resetList as resetUserHandlersState };
@@ -39,13 +42,25 @@ export const handlers = [
         dialect: "sqlite",
         usersTableReadable: true,
         usersRowCount: userList.length,
-        drizzleMigrationsCount: 1,
+        drizzleMigrationsCount: 4,
       },
     };
     return HttpResponse.json(body);
   }),
 
   http.get("/api/users", () => HttpResponse.json(userList)),
+
+  http.get("/api/users/:userId/payment-methods", ({ params }) => {
+    const userId = Array.isArray(params.userId) ? params.userId[0] : params.userId;
+    if (!userId) {
+      return HttpResponse.json({ error: "Missing user id" }, { status: 400 });
+    }
+    if (!userList.some((u) => u.id === userId)) {
+      return HttpResponse.json({ error: "User not found." }, { status: 404 });
+    }
+    const rows = paymentMethodList.filter((p) => p.userId === userId);
+    return HttpResponse.json(rows);
+  }),
 
   http.post("/api/users", async ({ request }) => {
     const body = (await request.json()) as { name?: string; email?: string; role?: string };
@@ -109,6 +124,7 @@ export const handlers = [
       return HttpResponse.json({ error: "User not found." }, { status: 404 });
     }
     userList = userList.filter((u) => u.id !== id);
+    paymentMethodList = paymentMethodList.filter((p) => p.userId !== id);
     return new HttpResponse(null, { status: 204 });
   }),
 ];

--- a/src/pages/UserPaymentMethodsPage.tsx
+++ b/src/pages/UserPaymentMethodsPage.tsx
@@ -1,0 +1,86 @@
+import { usePaymentMethods } from "@/api/paymentMethods";
+import { OtuPaymentMethodCard } from "@/components/OtuPaymentMethodCard";
+import { Button } from "@/components/ui/button";
+import { DEMO_ALICE_USER_ID } from "@/demo/constants";
+import { Link, getRouteApi } from "@tanstack/react-router";
+import { useCallback, useEffect, useState } from "react";
+
+const routeApi = getRouteApi("/users/$userId/payment-methods");
+
+export function UserPaymentMethodsPage() {
+  const { userId } = routeApi.useParams();
+  const { data, isPending, isError, error } = usePaymentMethods(userId);
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+  const [copyFailed, setCopyFailed] = useState(false);
+
+  useEffect(() => {
+    if (!copiedId) return;
+    const t = globalThis.setTimeout(() => setCopiedId(null), 2000);
+    return () => globalThis.clearTimeout(t);
+  }, [copiedId]);
+
+  const onCopy = useCallback(async (id: string, cardNumber: string) => {
+    setCopyFailed(false);
+    try {
+      await navigator.clipboard.writeText(cardNumber);
+      setCopiedId(id);
+    } catch {
+      setCopyFailed(true);
+    }
+  }, []);
+
+  if (isPending) {
+    return <p className="text-muted-foreground">Loading payment methods…</p>;
+  }
+
+  if (isError) {
+    return (
+      <div role="alert" className="text-destructive">
+        {error instanceof Error ? error.message : "Failed to load payment methods."}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-xl font-semibold tracking-tight">One-time use cards</h1>
+          <p className="text-muted-foreground text-sm">
+            Full numbers for issued cards. Production should encrypt at rest and meet PCI controls.
+          </p>
+        </div>
+        <Button variant="outline" asChild>
+          <Link to="/users">Back to users</Link>
+        </Button>
+      </div>
+
+      <p className="sr-only" aria-live="polite">
+        {copiedId ? "Card number copied to clipboard." : ""}
+      </p>
+      {copyFailed ? (
+        <p role="alert" className="text-destructive text-sm">
+          Clipboard unavailable. Copy the number manually.
+        </p>
+      ) : null}
+
+      {data.length === 0 ? (
+        <p className="text-muted-foreground">No cards for this user.</p>
+      ) : (
+        <ul className="flex flex-col gap-4" aria-label="Payment methods">
+          {data.map((pm) => (
+            <li key={pm.id}>
+              <OtuPaymentMethodCard pm={pm} copiedId={copiedId} onCopy={onCopy} />
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {userId === DEMO_ALICE_USER_ID ? (
+        <p className="text-muted-foreground text-xs">
+          Demo seed data — same rows as local SQLite when using default seeds.
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/router.test.tsx
+++ b/src/router.test.tsx
@@ -1,6 +1,7 @@
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it } from "vitest";
+import { DEMO_ALICE_USER_ID } from "./demo/constants";
 import { useUiStore } from "./store/uiStore";
 import { renderWithRouter } from "./test/utils";
 
@@ -12,6 +13,21 @@ describe("router", () => {
   it("renders UsersPage at /users", async () => {
     renderWithRouter({ initialPath: "/users" });
     await waitFor(() => expect(screen.getByText("Alice Admin")).toBeInTheDocument());
+  });
+
+  it("renders OTU payment methods for a user", async () => {
+    const user = userEvent.setup();
+    renderWithRouter({
+      initialPath: `/users/${DEMO_ALICE_USER_ID}/payment-methods`,
+    });
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /one-time use cards/i })).toBeInTheDocument()
+    );
+    expect(screen.getAllByText("•••• •••• •••• ••••").length).toBeGreaterThan(0);
+    await user.click(screen.getAllByRole("button", { name: /^show$/i })[0]);
+    await waitFor(() =>
+      expect(screen.getAllByText("4242 4242 4242 4242").length).toBeGreaterThan(0)
+    );
   });
 
   it("redirects / to /users", async () => {

--- a/src/router.ts
+++ b/src/router.ts
@@ -11,6 +11,7 @@ import { ComponentsDemoPage } from "./pages/ComponentsDemoPage";
 import { DashboardDemoPage } from "./pages/DashboardDemoPage";
 import { PlaygroundPage } from "./pages/PlaygroundPage";
 import { ShipReportPage } from "./pages/ShipReportPage";
+import { UserPaymentMethodsPage } from "./pages/UserPaymentMethodsPage";
 import { UsersPage } from "./pages/UsersPage";
 
 const rootRoute = createRootRoute({ component: App });
@@ -29,6 +30,12 @@ const usersRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/users",
   component: UsersPage,
+});
+
+const userPaymentMethodsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/users/$userId/payment-methods",
+  component: UserPaymentMethodsPage,
 });
 
 const playgroundRoute = createRoute({
@@ -64,6 +71,7 @@ const shipReportRoute = createRoute({
 const routeTree = rootRoute.addChildren([
   indexRoute,
   usersRoute,
+  userPaymentMethodsRoute,
   playgroundRoute,
   componentsDemoRoute,
   dashboardDemoRoute,


### PR DESCRIPTION
## Summary

- Add SQLite `payment_methods` (PAN, CVV, brand, label, expiry) with Drizzle migrations and demo seed data (test PANs only).
- Add `ensureDemoSeed` so fixture users and payment rows are inserted idempotently when the DB already has data.
- Expose `GET /api/users/:userId/payment-methods`, client fetch + TanStack Query hook, and MSW handlers for tests.
- New route `/users/:id/payment-methods` with OTU card UI: masked PAN/expiry/CVV until **Show**; **Copy card number** only after reveal.
- Link from user cards and AppShell when viewing a user; shared `maskCardNumber` helpers and unit tests.

## Test plan

- [x] `pnpm test --run`
- [x] `pnpm typecheck`
- [x] `pnpm test:coverage --run` (gate passes)

## Coverage

- Vitest scoped totals (from `coverage/coverage-summary.json`): **lines 91.01%**, statements 91.01%, functions 85.29%, branches 78.22% — meets `vite.config.ts` thresholds (lines/statements 90%, functions 83%).

Made with [Cursor](https://cursor.com)