### PR TITLE
refactor(ai-rules): trim skill bloat and fix weak descriptions

### DIFF
--- a/.ai-rules/skills/commit/SKILL.md
+++ b/.ai-rules/skills/commit/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: commit
-description: Create commits, push, open PR. Git-only.
+description: >-
+  Create commits from uncommitted work, push, and open a PR. Use when the user
+  asks to commit, push, land changes, save work to git, stage and ship code, or
+  open a pull request. Enforces conventional commits and branch safety.
 ---
 
 **GitHub:** Prefer **`gh`** for PRs and GitHub API calls. Do not reach for GitHub MCP when `gh pr` / `gh api` suffices.
@@ -47,8 +50,9 @@ All commit messages **must** follow [Conventional Commits](https://www.conventio
 3. **Group** into commits (list plan: title, why, files per commit; ask if unclear).
 4. `git add` / `git add -p` → `git commit` with heredoc message.
 5. After all commits: `git log --oneline`, spot-check `git show --name-only` per commit.
-6. **Push before calling the commit done:** `git ls-remote --heads origin <branch>` empty → `git push -u origin <branch>`. Else `git fetch origin <branch>` then push or force-with-lease as needed. `git status -s` after push.
-7. **PR before calling the commit done:** `gh pr view` if one exists; otherwise `gh pr create` with `## Summary` + `## Test plan` + `## Coverage` (paste Vitest % from `pnpm test:coverage` or point to the CI **Coverage** summary; note any waiver vs the gate in `vite.config.ts`). Return the PR URL.
+6. **Coverage check before push:** `pnpm test:coverage` — all thresholds in `vite.config.ts` must pass. If a threshold fails, fix the gap or obtain an explicit team waiver before continuing. Do not skip or suppress; catching this here avoids a CI failure that blocks the PR.
+7. **Push before calling the commit done:** `git ls-remote --heads origin <branch>` empty → `git push -u origin <branch>`. Else `git fetch origin <branch>` then push or force-with-lease as needed. `git status -s` after push.
+8. **PR before calling the commit done:** `gh pr view` if one exists; otherwise `gh pr create` with `## Summary` + `## Test plan` + `## Coverage` (paste Vitest % from step 6; note any waiver vs the gate in `vite.config.ts`). Return the PR URL.
 
 ## Common
 

--- a/.ai-rules/skills/route/SKILL.md
+++ b/.ai-rules/skills/route/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: route
-description: /route — Add/change TanStack Router routes; keep `AppShell` nav in sync.
+description: >-
+  Add or change TanStack Router routes and keep AppShell navigation in sync. Use
+  when adding, removing, or modifying routes, pages, nav links, or redirects in
+  this repo.
 ---
 
 # /route

--- a/.ai-rules/skills/safe-dependency-updates/SKILL.md
+++ b/.ai-rules/skills/safe-dependency-updates/SKILL.md
@@ -10,88 +10,66 @@ description: >-
 
 # Safe dependency updates
 
-Treat dependency work like a **controlled release program**: discover everything that is stale, **read the changelogs before touching versions**, classify risk, then land **small, reversible PRs** with green `pnpm verify` (per root `CLAUDE.md`).
-
-Public skill ecosystems (e.g. agent-skills “dependency-updater” / “dependency-upgrade” patterns) emphasize the same pillars: **semver-aware ordering**, **changelog and breaking-change review**, **security priority**, and **staged validation**. This repo encodes that in **agent roles** and **verification**, not in ad-hoc bumps.
+Treat dependency work like a **controlled release program**: discover everything that is stale, **read the changelogs before touching versions**, classify risk, then land **small, reversible PRs** with green `pnpm verify`.
 
 ## Discovery (full candidate set)
 
-Run from repo root and **capture outputs in the risk matrix artifact** (or PR appendix).
+Run from repo root and capture outputs in the risk matrix.
 
-1. **Declared drift:** `pnpm outdated` (all dependency types the project uses: `dependencies`, `devDependencies`, optional peers if listed).
-2. **Install-time signals (mandatory targets):** Run a clean-enough install path and record **every** package the tool names as outdated, deprecated, extraneous, or peer-mismatched:
-   - `pnpm install` (or `pnpm install --frozen-lockfile` on CI) and copy warnings.
-   - If resolving peers: `pnpm why <package>` for anything unclear.
-3. **Security:** `pnpm audit` (or `pnpm audit --json` for sorting). CVEs **elevate** severity and often justify an expedited patch/minor path—still read release notes.
-4. **Lockfile truth:** Diff `pnpm-lock.yaml` on another machine or after `git clean` if you suspect skew; the matrix should reflect **what the lock actually resolves**, not only `package.json` ranges.
+1. **Declared drift:** `pnpm outdated` (all dependency types).
+2. **Install-time signals:** `pnpm install` and copy every warning about outdated, deprecated, extraneous, or peer-mismatched packages. Use `pnpm why <package>` for anything unclear.
+3. **Security:** `pnpm audit` (or `pnpm audit --json`). CVEs elevate severity and often justify an expedited path — still read release notes.
+4. **Lockfile truth:** The matrix should reflect **what the lock actually resolves**, not only `package.json` ranges.
 
-**Rule:** Anything reported as outdated or risky during install **must** appear in the matrix as either “in scope for this batch” or “deferred” with a reason (e.g. blocked on another major).
+Anything reported as outdated or risky during install **must** appear in the matrix as "in scope" or "deferred" with a reason.
 
 ## Changelog and compatibility review (non-negotiable)
 
-Before changing a version, gather **primary** sources in this order:
+Before changing a version:
 
-1. **Release notes / CHANGELOG** on the package repo (GitHub Releases or `CHANGELOG.md`).
+1. **Release notes / CHANGELOG** on the package repo.
 2. **Migration guide** (often linked from major releases).
-3. **Diff or compare** between current locked version and target (tags or `vX.Y.Z`…`vA.B.C` on GitHub).
-4. **Peer and engine fields** in the new version (`peerDependencies`, `engines`, `package.json` exports).
+3. **Diff** between current locked version and target on GitHub.
+4. **Peer and engine fields** in the new version (`peerDependencies`, `engines`, `exports`).
 
-**Explicitly scan for:** breaking API removals, renamed options, default behavior changes, dropped Node/browser support, ESM/CJS boundary changes, TypeScript type breaking changes, bundler plugin requirements, and **deprecated APIs** you still call.
+Explicitly scan for: breaking API removals, renamed options, default behavior changes, dropped Node/browser support, ESM/CJS boundary changes, TypeScript type breaking changes, bundler plugin requirements, deprecated APIs you still call.
 
 Assume **major** = breaking until the changelog proves otherwise. **Minor** can break types or timing; still skim notes.
 
 ## Risk matrix (required artifact)
 
-Create a table (markdown is fine). One row per **upgrade unit** (single package or a **tight ecosystem cluster** updated together, e.g. related `@tanstack/*` pins when the project already couples them).
+One row per **upgrade unit** (single package or tight ecosystem cluster updated together):
 
-Suggested columns:
+| Package(s) | Current (lock) | Target | Semver bump | Source | CVE? | Changelog signals | Blast radius | Batch ID |
+|---|---|---|---|---|---|---|---|---|
 
-| Package(s) | Current (lock) | Target | Semver bump | Source (outdated / install warn / audit) | Security (CVE / none) | Changelog signals (breaking / migration / none found) | Blast radius (tooling / server / client / native addon) | Coupling (peers, workspace, framework) | Batch ID | Suggested agent pass |
-
-**Severity triage (for ordering):**
-
-- **Critical:** known exploit, data risk, or broken build; patch/minor first when it fixes the issue.
-- **High:** major semver, native modules (`better-sqlite3`, etc.), router/framework core, or packages that touch many imports.
+**Severity triage:**
+- **Critical:** known exploit, data risk, or broken build.
+- **High:** major semver, native modules, router/framework core, or packages that touch many imports.
 - **Medium:** minor/patch with behavior or type churn in release notes.
 - **Low:** patch with narrow surface and clear notes.
 
-**Ordering:**
+**Ordering:** security fixes first → leaf deps with small blast radius → patches and minors → majors (one focused PR each; never mix unrelated majors).
 
-1. Security fixes that match the triage above.
-2. **Leaf** dependencies with small blast radius.
-3. **Patches and minors** before **majors** unless a major blocks others.
-4. **Majors:** one focused PR (or one cluster) each; never mix unrelated majors in one diff.
+## Agent deployment
 
-## Agent deployment (who does what)
-
-Use **Lead** (`.ai-rules/agents/lead.md`) for branch scope: **one batch = one branch/PR** unless trivial patch-only sweeps are pre-approved in the matrix.
+**Lead** (`.ai-rules/agents/lead.md`) for branch scope: **one batch = one branch/PR** unless trivial patch-only sweeps are pre-approved in the matrix.
 
 | Phase | Agent | Responsibility |
 |-------|--------|----------------|
-| Plan | **Architect** | Read-only upgrade plan: ordered batches, changelog citations, migration steps, files likely touched, **test plan** (what must pass: unit, e2e, smoke). Adapt the architect output format to dependency work (no feature Zod section unless APIs change). |
-| Gate | **Critic** | Red-team the plan: missed breaking changes, peer conflicts, missing rollback, insufficient tests for behavior changes. **BLOCK** until addressed. |
-| Implement | **Builder** | Apply version/lock changes for **one batch**; run **`pnpm verify`** (or at minimum typecheck + test:coverage + lint + build + fallow per `CLAUDE.md`). Follow **strict-tdd** when application behavior or types change—not for mechanical bumps that touch no code paths, but default to running the full suite anyway. |
-| Ship | **Reviewer** | Final diff and PR text: note semver, changelog highlights, **Breaking** section, **Coverage** numbers, and any skipped browser/DB verify with reason. |
+| Plan | **Architect** | Ordered batches, changelog citations, migration steps, test plan |
+| Gate | **Critic** | Red-team: missed breaking changes, peer conflicts, missing rollback. **BLOCK** until addressed. |
+| Implement | **Builder** | Apply version/lock changes for one batch; run `pnpm verify` |
+| Ship | **Reviewer** | PR text: semver, changelog highlights, Breaking section, Coverage numbers |
 
-**Native / server / DB packages:** include **drizzle-db-verify** or other live smoke steps from `CLAUDE.md` when those layers are affected.
-
-**UI/router bumps:** prefer **chrome-devtools-verify** when MCP is available.
-
-## Implementation discipline
-
-- Prefer **explicit version pins or caret bumps** consistent with repo convention; avoid “upgrade everything” in one commit.
-- After lockfile changes: **read the diff** for unexpected transitive upgrades; if a transitive major appeared, **add a row** to the matrix or pin/resolution per team policy.
-- Do not silence audit with `--force` without Lead approval and a documented exception.
-- No `any`, `@ts-ignore`, or `biome-ignore` to “finish” an upgrade without cause (per `CLAUDE.md`).
+**Native / server / DB packages:** include **drizzle-db-verify** when those layers are affected. **UI/router bumps:** prefer **chrome-devtools-verify** when MCP is available.
 
 ## Deferred work
 
-If a package cannot be upgraded yet, record **blocker**, **owner**, and **next trigger** (e.g. “waiting for Node 22” or “blocked on Storybook major”).
+Record **blocker**, **owner**, and **next trigger** for any package that cannot be upgraded yet (e.g. "waiting for Node 22" or "blocked on Storybook major").
 
 ## Output checklist
 
-- [ ] Discovery outputs attached (outdated, install warnings, audit summary).
-- [ ] Risk matrix complete; majors and native modules flagged.
-- [ ] Changelog/migration notes cited for each in-scope row.
+- [ ] Risk matrix complete; majors and native modules flagged; changelog cited per row.
 - [ ] Architect plan → Critic approval → Builder implementation → Reviewer PR.
-- [ ] `pnpm verify` green or documented waiver path per `CLAUDE.md`.
+- [ ] `pnpm verify` green.

--- a/.ai-rules/skills/ui-explore/SKILL.md
+++ b/.ai-rules/skills/ui-explore/SKILL.md
@@ -59,54 +59,27 @@ Select 4–5 that are genuinely distinct for the feature. Name each variant clea
 
 Create lightweight prototype components. Use real or realistic mock data — not "Lorem ipsum."
 
-### File locations
-
 ```
 src/pages/ui-explore/<feature-name>/
   index.tsx          ← wrapper page; renders all variants with a tab or toggle switcher
   TableVariant.tsx
   CardGridVariant.tsx
-  TimelineVariant.tsx
-  KanbanVariant.tsx
-  DashboardVariant.tsx
+  ...
 ```
 
-Or, if a single file is cleaner (few variants, simple layouts):
-
-```
-src/pages/ui-explore/<feature-name>.tsx
-```
-
-### Implementation rules
-
-- Use the same mock data object / array for every variant — define it once at the top of `index.tsx` and pass as a prop.
-- Use only existing shared components (`src/components/ui/`) — **do not install new UI libraries** for exploration.
-- Keep each variant self-contained and independently renderable.
-- Add a route for the exploration page (e.g. `/ui-explore/<feature-name>`) using the `route` skill so it's accessible in the browser.
-- No tests needed for exploration components — they are throwaway scaffolding.
-- Mark the route and components with a `// UI EXPLORE: remove before ship` comment.
-
-### Mock data conventions
-
-- Use a typed constant: `const MOCK_<FEATURE>: <Type>[] = [...]`
-- Include at least 6–8 records covering edge cases: long text, missing optional fields, extreme values, different statuses.
-- Mirror the shape of the real Zod schema so swapping in a TanStack Query hook later is trivial.
+- Define mock data once at the top of `index.tsx` and pass as a prop to every variant. Use a typed constant (`const MOCK_<FEATURE>: <Type>[] = [...]`) with 6–8 records covering edge cases (long text, missing optional fields, extreme values, different statuses). Mirror the real Zod schema shape so swapping in a TanStack Query hook later is trivial.
+- Use only existing shared components (`src/components/ui/`) — **do not install new UI libraries**.
+- Add a route (e.g. `/ui-explore/<feature-name>`) via the `route` skill and mark it `// UI EXPLORE: remove before ship`.
+- No tests needed — these are throwaway scaffolding.
 
 ---
 
 ## Step 4 — Screenshot each variant
 
-Start the dev server, navigate to the exploration route, and capture each variant.
-
 1. `pnpm dev:ready` — note Vite URL.
 2. `navigate_page` to `/ui-explore/<feature-name>`.
-3. For **each variant**:
-   - Switch to the variant (click the tab/toggle in the wrapper page).
-   - `take_snapshot`.
-   - `take_screenshot` → `verification/<branch>/ui-explore-<feature>-<variant>.png` (`fullPage: true`).
-   - Note 2–3 observations per variant (what this layout emphasises, what it hides).
-4. Optionally, for variants with interactions (e.g. Kanban drag, Table sort):
-   - `take_screenshot` before → interact → `take_screenshot` after. Use `before`/`after` naming.
+3. For **each variant**: switch to it, `take_snapshot`, `take_screenshot` → `verification/<branch>/ui-explore-<feature>-<variant>.png` (`fullPage: true`). Note 2–3 observations (what this layout emphasises, what it hides).
+4. For variants with interactions (Kanban drag, Table sort): **before** screenshot → interact → **after** screenshot with `before`/`after` naming.
 
 ---
 
@@ -133,49 +106,22 @@ Address **every medium and high** finding with **one** batch of UI changes in th
 
 ## Step 7 — Present comparison
 
-Produce a structured comparison the team can react to.
-
 ```markdown
 ## UI Exploration — <feature name>
 
 **Data shape:** <summary of fields used>
 **Primary action:** <the task each variant must support>
-**Branch:** <branch name>
 
 ### Variants
 
-#### 1. Table View
-![table](verification/<branch>/ui-explore-<feature>-table.png)
+#### 1. <Variant name>
+![variant](verification/<branch>/ui-explore-<feature>-<variant>.png)
 
-**Strengths:** Dense, sortable, familiar for data-heavy workflows.  
-**Weaknesses:** No visual scanning; status is easy to miss.  
-**Best for:** Power users who know what they're looking for.
+**Strengths:** ...
+**Weaknesses:** ...
+**Best for:** ...
 
-#### 2. Card Grid
-![cards](verification/<branch>/ui-explore-<feature>-cards.png)
-
-**Strengths:** Status and key metadata visible at a glance.  
-**Weaknesses:** Lower information density; pagination required sooner.  
-**Best for:** Moderate record counts; scanning by visual cue.
-
-#### 3. Timeline / Feed
-...
-
-#### 4. Kanban Board
-...
-
-#### 5. Stat Dashboard
-...
-
-### Comparison Table
-
-| Criterion | Table | Card Grid | Timeline | Kanban | Dashboard |
-|-----------|-------|-----------|----------|--------|-----------|
-| Information density | ★★★★★ | ★★★☆☆ | ★★☆☆☆ | ★★★☆☆ | ★★★★☆ |
-| Scannability | ★★☆☆☆ | ★★★★☆ | ★★★☆☆ | ★★★★☆ | ★★★☆☆ |
-| Primary action support | ★★★★☆ | ★★★☆☆ | ★★☆☆☆ | ★★★★★ | ★★☆☆☆ |
-| Mobile-friendliness | ★★☆☆☆ | ★★★★☆ | ★★★★★ | ★★☆☆☆ | ★★★☆☆ |
-| Implementation complexity | Low | Low | Medium | High | High |
+#### 2. ...
 
 ### Recommendation
 <Suggested variant and rationale, or "ask the team to pick" if genuinely even>
@@ -191,25 +137,10 @@ Produce a structured comparison the team can react to.
 
 ## Cleanup
 
-After the team picks a direction:
-
-1. Delete `src/pages/ui-explore/<feature-name>/` (or the exploration file).
-2. Remove the exploration route from the router.
-3. Implement the chosen variant in its proper location with a real TanStack Query hook.
-4. Run `/ship` to implement, test, and verify.
-5. Run `ux-critique` on the final result if UX quality needs a second pass before merge.
-
----
+Delete `src/pages/ui-explore/<feature-name>/`, remove the route, implement the chosen variant in its proper location with a real TanStack Query hook, then run `/ship`.
 
 ## Checklist
 
-- [ ] Feature, data shape, primary action, and user defined
-- [ ] 4–5 genuinely distinct archetypes chosen (not near-duplicates)
-- [ ] Same typed mock data used across all variants
-- [ ] Route added; dev server confirms it renders
-- [ ] Screenshot for each variant saved to `verification/<branch>/ui-explore-<feature>-<variant>.png`
 - [ ] One `ux-critique` round completed; findings saved to `verification/<branch-slug>/ui-explore-<feature>-ux-findings.md`
 - [ ] One iteration applied; medium+ findings addressed (or documented as wont-fix)
-- [ ] Comparison table with strengths/weaknesses for each variant
-- [ ] Recommendation or explicit "team decides" call made
-- [ ] Cleanup plan noted (exploration components are not shipped)
+- [ ] Recommendation made (or explicit "team decides")

--- a/.ai-rules/skills/ux-critique/SKILL.md
+++ b/.ai-rules/skills/ux-critique/SKILL.md
@@ -27,8 +27,8 @@ Pick a mode from the user's request, or default to **full audit** on the primary
 
 ## Setup
 
-1. `pnpm dev:ready` (or `pnpm dev`) — note Vite URL (usually `:5173`).
-2. `list_pages` — confirm MCP is connected and note the page ID.
+1. `pnpm dev:ready` — note Vite URL (usually `:5173`).
+2. `list_pages` — confirm MCP is connected.
 3. Define **scope**: which route(s) or flow(s) to evaluate.
 4. Define **persona** if running a flow (template below).
 
@@ -36,16 +36,10 @@ Pick a mode from the user's request, or default to **full audit** on the primary
 
 ## Mode 1: Heuristic Sweep
 
-**Goal:** Rate a page against Nielsen's 10 Usability Heuristics.
-
-### Steps
-
-1. `navigate_page` to the target URL.
-2. `take_snapshot` — record element UIDs.
-3. `take_screenshot` → `verification/<branch>/ux-<route>-01-load.png` (`fullPage: true`).
-4. Screenshot each distinct state (empty, loaded, error) separately.
-5. For interactive elements (dropdowns, modals, accordions): `take_screenshot` **before** the interaction → interact → `take_snapshot` → `take_screenshot` **after**. Use paired names: `ux-<route>-02-before-<action>.png` / `ux-<route>-03-after-<action>.png`.
-6. Evaluate each heuristic (table below), note evidence and severity.
+1. `navigate_page` → `take_snapshot` → `take_screenshot` to `verification/<branch>/ux-<route>-01-load.png` (`fullPage: true`).
+2. Screenshot each distinct state (empty, loaded, error) separately.
+3. For interactive elements: **before** screenshot → interact → `take_snapshot` → **after** screenshot. Use paired names: `ux-<route>-02-before-<action>.png` / `ux-<route>-03-after-<action>.png`.
+4. Evaluate each heuristic below, note evidence and severity.
 
 ### Nielsen's 10 Heuristics
 
@@ -66,11 +60,7 @@ Pick a mode from the user's request, or default to **full audit** on the primary
 
 ## Mode 2: Persona Flow
 
-**Goal:** Simulate a real user completing a task; measure friction and completion.
-
-### Persona Template
-
-Ask the user if unclear; otherwise infer from context:
+Define the persona (ask the user if unclear; otherwise infer from context):
 
 ```
 Persona: <role + technical level, e.g. "first-time user, non-technical, on a laptop">
@@ -82,32 +72,13 @@ Task sequence:
 Success criteria: <what "done" looks like>
 ```
 
-### Steps
+For **each task step**: `take_snapshot` → **before** screenshot → `click` / `fill` / `type_text` → **after** screenshot. Log friction (confusing labels, missing affordances, unexpected state) and tag the relevant heuristic.
 
-1. `navigate_page` to starting URL.
-2. For **each task step**:
-   - `take_snapshot` to get fresh UIDs.
-   - `take_screenshot` before interaction → `ux-flow-<N>-before-<step>.png`.
-   - `click` / `fill` / `type_text` to perform the step.
-   - `take_screenshot` after → `ux-flow-<N>-after-<step>.png`.
-   - Log friction: confusing labels, missing affordances, unexpected state.
-3. `list_console_messages` — note errors/warnings that appeared during the flow.
-4. `list_network_requests` — flag failed requests or unexpected latency (>2 s).
-5. Score: did the persona complete the goal? How many steps? Any dead ends?
-
-### Friction Log (fill per step)
-
-| Step | Before screenshot | After screenshot | Friction observed | Heuristic | Severity |
-|------|-------------------|-----------------|-------------------|-----------|----------|
-| 1 — … | `ux-flow-01-before-…` | `ux-flow-01-after-…` | — | — | — |
+After the flow: `list_console_messages` (errors/warnings) and `list_network_requests` (failed or slow >2 s). Score: did the persona complete the goal? How many steps? Any dead ends?
 
 ---
 
 ## Mode 3: Error Injection
-
-**Goal:** Verify error states are clear, recoverable, and non-alarming.
-
-### Scenarios to test
 
 | Scenario | How to trigger |
 |----------|---------------|
@@ -116,14 +87,7 @@ Success criteria: <what "done" looks like>
 | Unauthorized | Access a protected resource without credentials |
 | Not found | Navigate to a non-existent route (e.g. `/does-not-exist`) |
 
-For each:
-1. `take_screenshot` before trigger → `ux-error-<type>-01-before.png`.
-2. Trigger the error.
-3. `take_snapshot` then `take_screenshot` → `ux-error-<type>-02-after.png`.
-4. Evaluate against **H9** (recovery) and **H5** (prevention):
-   - Is the message in plain language?
-   - Does it say what went wrong and what to do next?
-   - Can the user recover without losing their work?
+For each: **before** screenshot → trigger → `take_snapshot` → **after** screenshot. Evaluate against **H9** (recovery) and **H5** (prevention): plain-language message, clear next step, no lost work.
 
 ---
 
@@ -135,14 +99,10 @@ Run automatically as part of any audit:
 lighthouse_audit(url: <current page URL>, categories: ["accessibility"])
 ```
 
-Key thresholds:
 - Lighthouse a11y score ≥ 90 → pass; < 90 → flag findings.
-- Color contrast ≥ 4.5:1 (normal text), ≥ 3:1 (large text, UI components).
-- All interactive elements have visible focus rings.
-- Form inputs have visible labels (not just placeholder).
-- Images have `alt` text.
-- ARIA roles used correctly (no `role="button"` on non-interactive elements).
-- Tab order is logical; no focus traps.
+- Color contrast ≥ 4.5:1 (normal text), ≥ 3:1 (large text/UI components).
+- Interactive elements have visible focus rings; form inputs have visible labels.
+- Images have `alt` text; ARIA roles used correctly; tab order is logical.
 
 ---
 
@@ -178,15 +138,11 @@ Key thresholds:
 - **Goal:** <goal>
 - **Completed:** Yes / No / Partial
 - **Steps taken:** N (expected: M)
-- **Dead ends encountered:** none / <describe>
+- **Dead ends:** none / <describe>
 
 ### Accessibility
 - Lighthouse a11y score: XX/100
 - Blockers: <list or "none">
-
-### Screenshots
-- `verification/<branch>/ux-01-load.png`
-- ...
 
 ### Follow-ups
 - [ ] Critical: <fix description> — **blocks ship**

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ verification/*
 *.sqlite
 *.sqlite-shm
 *.sqlite-wal
+.worktrees/


### PR DESCRIPTION
## Summary

- **`ux-critique` −44 lines:** collapsed mode step prose, condensed a11y bullets, dropped the empty friction-log table template that added noise without value
- **`ui-explore` −73 lines:** merged scattered implementation rules into prose, removed the star-rating comparison table example and the standalone end-checklist (which restated the steps)
- **`safe-dependency-updates` −22 lines:** removed meta commentary about public skill ecosystems and an implementation-discipline section that duplicated CLAUDE.md rules
- **`commit`:** added explicit pre-push coverage-check step (`pnpm test:coverage` must pass before pushing); strengthened description for better skill triggering
- **`route`:** fixed description — was prefixed with `/route —` (a slash-command pattern, not a trigger phrase), now describes what the skill does in natural language

## Coverage

No source code changed — skills are `.md` files. All 65 Vitest tests pass.

## Verification

Tests: 65 passed (20 files), 0 failures.
Fallow: n/a (markdown only, no TS changed).