### PR TITLE
docs(ai-rules): require coverage check before push in commit skill

### DIFF
--- a/.ai-rules/skills/commit/SKILL.md
+++ b/.ai-rules/skills/commit/SKILL.md
@@ -47,8 +47,9 @@ All commit messages **must** follow [Conventional Commits](https://www.conventio
 3. **Group** into commits (list plan: title, why, files per commit; ask if unclear).
 4. `git add` / `git add -p` → `git commit` with heredoc message.
 5. After all commits: `git log --oneline`, spot-check `git show --name-only` per commit.
-6. **Push before calling the commit done:** `git ls-remote --heads origin <branch>` empty → `git push -u origin <branch>`. Else `git fetch origin <branch>` then push or force-with-lease as needed. `git status -s` after push.
-7. **PR before calling the commit done:** `gh pr view` if one exists; otherwise `gh pr create` with `## Summary` + `## Test plan` + `## Coverage` (paste Vitest % from `pnpm test:coverage` or point to the CI **Coverage** summary; note any waiver vs the gate in `vite.config.ts`). Return the PR URL.
+6. **Coverage check before push:** `pnpm test:coverage` — all thresholds in `vite.config.ts` must pass. If a threshold fails, fix the gap or obtain an explicit team waiver before continuing. Do not skip or suppress; catching this here avoids a CI failure that blocks the PR.
+7. **Push before calling the commit done:** `git ls-remote --heads origin <branch>` empty → `git push -u origin <branch>`. Else `git fetch origin <branch>` then push or force-with-lease as needed. `git status -s` after push.
+8. **PR before calling the commit done:** `gh pr view` if one exists; otherwise `gh pr create` with `## Summary` + `## Test plan` + `## Coverage` (paste Vitest % from step 6; note any waiver vs the gate in `vite.config.ts`). Return the PR URL.
 
 ## Common
 


### PR DESCRIPTION
## Summary

- Add an explicit **coverage check before push** step to the `.ai-rules` commit skill so agents run `pnpm test:coverage` and satisfy `vite.config.ts` thresholds before opening PRs, reducing avoidable CI failures.
- Renumber follow-on steps (push, PR) and align the PR step’s coverage note with the new step order.

## Test plan

- [x] `pnpm test:coverage` passes locally (see Coverage).

## Coverage

- All files: **94.38%** statements, **87.08%** branches, **83.67%** functions, **94.38%** lines (Vitest v8, current thresholds in `vite.config.ts`).

Made with [Cursor](https://cursor.com)